### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: 6.0.x
           include-prerelease: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
       with:
         token: ${{ secrets.SBPAT }}
         persist-credentials: true
@@ -28,18 +28,18 @@ jobs:
 
     - name: Get changelog entries
       id: changelog
-      uses: mindsers/changelog-reader-action@v2
+      uses: mindsers/changelog-reader-action@v2.2.0
       with:
         version: Unreleased
         path: ./CHANGELOG.md
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.3
       with:
         dotnet-version: 6.0.x
 
     - name: Update CHANGELOG file
-      uses: thomaseizinger/keep-a-changelog-new-release@1.2.1
+      uses: thomaseizinger/keep-a-changelog-new-release@1.3.0
       with:
         version: ${{ github.event.inputs.versionIncrement }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.1.0
 
     - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.0.3
       with:
         dotnet-version: 6.0.x
 
     - name: Setup DocFX
-      uses: crazy-max/ghaction-chocolatey@v1
+      uses: crazy-max/ghaction-chocolatey@v2.1.0
       with:
         args: install docfx
 
@@ -31,7 +31,7 @@ jobs:
 
     - name: Publish
       if: github.event_name == 'push'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v3.9.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/site/_site

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.1.0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3.0.3
       with:
         dotnet-version: 6.0.x
         include-prerelease: true

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.1.0
       with:
         token: ${{ secrets.SBPAT }}
         persist-credentials: false
@@ -32,7 +32,7 @@ jobs:
         git merge --no-ff -X theirs origin/main -m "Updating to newest release"
         
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.SBPAT }}
         branch: stable


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[thomaseizinger/keep-a-changelog-new-release](https://github.com/thomaseizinger/keep-a-changelog-new-release)** published a new release **[1.3.0](https://github.com/thomaseizinger/keep-a-changelog-new-release/releases/tag/1.3.0)** on 2021-10-12T05:53:04Z
* **[crazy-max/ghaction-chocolatey](https://github.com/crazy-max/ghaction-chocolatey)** published a new release **[v2.1.0](https://github.com/crazy-max/ghaction-chocolatey/releases/tag/v2.1.0)** on 2022-10-18T20:09:05Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release **[v0.6.0](https://github.com/ad-m/github-push-action/releases/tag/v0.6.0)** on 2020-05-26T20:53:18Z
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v3.0.3](https://github.com/actions/setup-dotnet/releases/tag/v3.0.3)** on 2022-10-27T13:09:53Z
* **[peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages)** published a new release **[v3.9.0](https://github.com/peaceiris/actions-gh-pages/releases/tag/v3.9.0)** on 2022-10-23T15:00:08Z
* **[mindsers/changelog-reader-action](https://github.com/mindsers/changelog-reader-action)** published a new release **[v2.2.0](https://github.com/mindsers/changelog-reader-action/releases/tag/v2.2.0)** on 2022-09-01T11:20:01Z
