### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Get changelog entries
       id: changelog
-      uses: mindsers/changelog-reader-action@v2.2.0
+      uses: mindsers/changelog-reader-action@v2.2.1
       with:
         version: Unreleased
         path: ./CHANGELOG.md


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[mindsers/changelog-reader-action](https://github.com/mindsers/changelog-reader-action)** published a new release **[v2.2.1](https://github.com/mindsers/changelog-reader-action/releases/tag/v2.2.1)** on 2022-11-10T15:35:23Z
