### PR TITLE
Fix index out of range exception issue

### DIFF
--- a/src/LinkDotNet.StringBuilder/NaiveSearch.cs
+++ b/src/LinkDotNet.StringBuilder/NaiveSearch.cs
@@ -22,7 +22,7 @@ internal static class NaiveSearch
 
         var hits = new TypedSpanList<int>();
 
-        for (var i = 0; i < text.Length; i++)
+        for (var i = 0; i < text.Length - word.Length + 1; i++)
         {
             for (var j = 0; j < word.Length; j++)
             {

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Replace.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Replace.Tests.cs
@@ -77,6 +77,16 @@ public class ValueStringBuilderReplaceTests
         builder.ToString().Should().Be("Hallöchen World");
     }
 
+    [Fact]
+    public void ShouldReplacePartThatIsPartiallySimilar()
+    {
+        using var builder = new ValueStringBuilder("Hello ##Key##");
+
+        builder.Replace("##Key##", "World");
+
+        builder.ToString().Should().Be("Hello World");
+    }
+
     [Theory]
     [InlineData("", "word")]
     [InlineData("word", "")]


### PR DESCRIPTION
This PR resolves `IndexOutOfRangeException` in `FindAll` method by optimizing text search. It prevents unnecessary iterations when the remaining text length is shorter than the search term.

**Steps to reproduce:**
```csharp
using var builder = new ValueStringBuilder("Hello ##Key##");
builder.Replace("##Key##", "World");
```