### PR TITLE
Add MIT license to NuGet package

### DIFF
--- a/src/LinkDotNet.StringBuilder/LinkDotNet.StringBuilder.csproj
+++ b/src/LinkDotNet.StringBuilder/LinkDotNet.StringBuilder.csproj
@@ -37,6 +37,7 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<AnalysisLevel>8</AnalysisLevel>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The repository has the MIT license but it's missing from the NuGet package.