### PR TITLE
Support System.Text.Rune

### DIFF
--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
@@ -143,11 +143,12 @@ public ref partial struct ValueStringBuilder
     /// <summary>
     /// Does the same as <see cref="Append(char)"/> but adds a newline at the end.
     /// </summary>
-    /// <param name="str">String, which will be added to this builder.</param>
+    /// <param name="str">String to be added to this builder.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendLine(scoped ReadOnlySpan<char> str)
     {
-        Append(string.Concat(str, Environment.NewLine));
+        Append(str);
+        Append(Environment.NewLine);
     }
 
     /// <summary>

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace LinkDotNet.StringBuilder;
 
@@ -115,6 +116,19 @@ public ref partial struct ValueStringBuilder
 
         buffer[bufferPosition] = value;
         bufferPosition++;
+    }
+
+    /// <summary>
+    /// Appends a single rune to the string builder.
+    /// </summary>
+    /// <param name="value">Rune to add.</param>
+    public void Append(Rune value)
+    {
+        Span<char> valueChars = stackalloc char[2];
+        int valueCharsWritten = value.EncodeToUtf16(valueChars);
+        ReadOnlySpan<char> valueCharsReadOnly = valueChars[..valueCharsWritten];
+
+        Append(valueCharsReadOnly);
     }
 
     /// <summary>

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
@@ -122,6 +122,7 @@ public ref partial struct ValueStringBuilder
     /// Appends a single rune to the string builder.
     /// </summary>
     /// <param name="value">Rune to add.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Append(Rune value)
     {
         Span<char> valueChars = stackalloc char[2];

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.AppendJoin.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.AppendJoin.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace LinkDotNet.StringBuilder;
 
@@ -8,7 +9,7 @@ public ref partial struct ValueStringBuilder
     /// Concatenates and appends all values with the given separator between each entry at the end of the string.
     /// </summary>
     /// <param name="separator">String used as separator between the entries.</param>
-    /// <param name="values">Array of strings, which will be concatenated.</param>
+    /// <param name="values">Enumerable of strings to be concatenated.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendJoin(ReadOnlySpan<char> separator, IEnumerable<string?> values)
         => AppendJoinInternalString(separator, values);
@@ -17,7 +18,7 @@ public ref partial struct ValueStringBuilder
     /// Concatenates and appends all values with the given separator between each entry at the end of the string.
     /// </summary>
     /// <param name="separator">Character used as separator between the entries.</param>
-    /// <param name="values">Array of strings, which will be concatenated.</param>
+    /// <param name="values">Enumerable of strings to be concatenated.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendJoin(char separator, IEnumerable<string?> values)
         => AppendJoinInternalChar(separator, values);
@@ -25,9 +26,18 @@ public ref partial struct ValueStringBuilder
     /// <summary>
     /// Concatenates and appends all values with the given separator between each entry at the end of the string.
     /// </summary>
+    /// <param name="separator">Rune used as separator between the entries.</param>
+    /// <param name="values">Enumerable of strings to be concatenated.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AppendJoin(Rune separator, IEnumerable<string?> values)
+        => AppendJoinInternalRune(separator, values);
+
+    /// <summary>
+    /// Concatenates and appends all values with the given separator between each entry at the end of the string.
+    /// </summary>
     /// <param name="separator">String used as separator between the entries.</param>
-    /// <param name="values">Array of strings, which will be concatenated.</param>
-    /// <typeparam name="T">Type of the given array.</typeparam>
+    /// <param name="values">Enumerable to be concatenated.</param>
+    /// <typeparam name="T">Type of the given enumerable.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendJoin<T>(ReadOnlySpan<char> separator, IEnumerable<T> values)
         => AppendJoinInternalString(separator, values);
@@ -36,11 +46,21 @@ public ref partial struct ValueStringBuilder
     /// Concatenates and appends all values with the given separator between each entry at the end of the string.
     /// </summary>
     /// <param name="separator">Character used as separator between the entries.</param>
-    /// <param name="values">Array of strings, which will be concatenated.</param>
-    /// <typeparam name="T">Type of the given array.</typeparam>
+    /// <param name="values">Enumerable to be concatenated.</param>
+    /// <typeparam name="T">Type of the given enumerable.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendJoin<T>(char separator, IEnumerable<T> values)
         => AppendJoinInternalChar(separator, values);
+
+    /// <summary>
+    /// Concatenates and appends all values with the given separator between each entry at the end of the string.
+    /// </summary>
+    /// <param name="separator">Rune used as separator between the entries.</param>
+    /// <param name="values">Enumerable to be concatenated.</param>
+    /// <typeparam name="T">Type of the given enumerable.</typeparam>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AppendJoin<T>(Rune separator, IEnumerable<T> values)
+        => AppendJoinInternalRune(separator, values);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AppendJoinInternalString<T>(ReadOnlySpan<char> separator, IEnumerable<T> values)
@@ -55,10 +75,7 @@ public ref partial struct ValueStringBuilder
         }
 
         var current = enumerator.Current;
-        if (current is not null)
-        {
-            AppendInternal(current);
-        }
+        AppendInternal(current);
 
         while (enumerator.MoveNext())
         {
@@ -86,6 +103,29 @@ public ref partial struct ValueStringBuilder
         while (enumerator.MoveNext())
         {
             AppendInternal(separator);
+            current = enumerator.Current;
+            AppendInternal(current);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AppendJoinInternalRune<T>(Rune separator, IEnumerable<T> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        using var enumerator = values.GetEnumerator();
+
+        if (!enumerator.MoveNext())
+        {
+            return;
+        }
+
+        var current = enumerator.Current;
+        AppendInternal(current);
+
+        while (enumerator.MoveNext())
+        {
+            Append(separator);
             current = enumerator.Current;
             AppendInternal(current);
         }


### PR DESCRIPTION
Since `char` is a 16-bit UTF-16 character, it doesn't support characters outside the [BMP](https://en.wikipedia.org/wiki/Plane_(Unicode)) encoding range and need to be combined as surrogate pairs.
`Rune` is essentially a 32-bit UTF-32 character, and can support all Unicode characters, including emojis. It's wonderful.

This PR adds:
- `ValueStringBuilder.Append(Rune)`
- `ValueStringBuilder.AppendJoin(Rune, IEnumerable<string?>)`
- `ValueStringBuilder.AppendJoin<T>(Rune, IEnumerable<T>)`

This PR also optimises `AppendLine(scoped ReadOnlySpan<char>)` by avoiding an unnecessary string allocation. It also removes an unnecessary null check in `AppendJoinInternalString<T>(ReadOnlySpan<char>, IEnumerable<T>)`.