### PR TITLE
Generate documentation file

### DIFF
--- a/src/LinkDotNet.StringBuilder/LinkDotNet.StringBuilder.csproj
+++ b/src/LinkDotNet.StringBuilder/LinkDotNet.StringBuilder.csproj
@@ -19,6 +19,7 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <LangVersion>preview</LangVersion>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Concat.Helper.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Concat.Helper.cs
@@ -7,9 +7,9 @@ public ref partial struct ValueStringBuilder
     /// <summary>
     /// Concatenates multiple objects together.
     /// </summary>
-    /// <param name="values">Values, which will be concatenated together.</param>
+    /// <param name="values">Values to be concatenated together.</param>
     /// <typeparam name="T">Any given type, which can be translated to <see cref="string"/>.</typeparam>
-    /// <returns>Concatenated string or an empty string if <see cref="values"/> is empty.</returns>
+    /// <returns>Concatenated string or an empty string if <paramref name="values"/> is empty.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Concat<T>(params T[] values)
     {

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Enumerator.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Enumerator.cs
@@ -5,6 +5,10 @@ namespace LinkDotNet.StringBuilder;
 
 public ref partial struct ValueStringBuilder
 {
+    /// <summary>
+    /// Creates an enumerator over the characters in the builder.
+    /// </summary>
+    /// <returns>An enumerator over the characters in the builder.</returns>
     public readonly Enumerator GetEnumerator() => new(buffer[..bufferPosition]);
 
     /// <summary>Enumerates the elements of a <see cref="Span{T}"/>.</summary>

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
@@ -85,7 +85,7 @@ public ref partial struct ValueStringBuilder
     /// <summary>
     /// Returns the character at the given index or throws an <see cref="IndexOutOfRangeException"/> if the index is bigger than the string.
     /// </summary>
-    /// <param name="index">Index position, which should be retrieved.</param>
+    /// <param name="index">Character position to be retrieved.</param>
     public readonly ref char this[int index] => ref buffer[index];
 
     /// <summary>

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilderExtensions.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class ValueStringBuilderExtensions
     /// Creates a new <see cref="ValueStringBuilder"/> from the given <paramref name="builder"/>.
     /// </summary>
     /// <param name="builder">The builder from which the new instance is derived.</param>
-    /// <returns>A new <see cref="ValueStringBuilder"/> instance with the string represented by this <see cref="builder"/>.</returns>
+    /// <returns>A new <see cref="ValueStringBuilder"/> instance with the string represented by this builder.</returns>
     /// <exception cref="ArgumentNullException">Throws if <paramref name="builder"/> is null.</exception>
     public static ValueStringBuilder ToValueStringBuilder(this System.Text.StringBuilder? builder)
     {


### PR DESCRIPTION
It's come to my attention that none of the documentation is actually included in the NuGet package because the `GenerateDocumentationFile` tag is missing.
![image](https://github.com/user-attachments/assets/41dd6c1d-6b81-4653-b569-b0b7c24782d0)

This pull request adds it and fixes various errors.