### PR TITLE
Update packages & migrate to Shouldly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<ItemGroup>
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.4.0.108396">
+      <PackageReference Include="SonarAnalyzer.CSharp" Version="10.5.0.109200">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/LinkDotNet.StringBuilder/LinkDotNet.StringBuilder.csproj
+++ b/src/LinkDotNet.StringBuilder/LinkDotNet.StringBuilder.csproj
@@ -33,20 +33,24 @@
       </None>
     </ItemGroup>
 
-	<PropertyGroup Label="Analyzer settings">
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<AnalysisLevel>8</AnalysisLevel>
-		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
+    <PropertyGroup Label="Analyzer settings">
+        <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>8</AnalysisLevel>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Meziantou.Analyzer" Version="2.0.184">
+      <PackageReference Include="Meziantou.Analyzer" Version="2.0.186">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Update="SonarAnalyzer.CSharp" Version="10.5.0.109200">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/LinkDotNet.StringBuilder/LinkDotNet.StringBuilder.csproj
+++ b/src/LinkDotNet.StringBuilder/LinkDotNet.StringBuilder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
@@ -47,10 +47,6 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Update="SonarAnalyzer.CSharp" Version="10.5.0.109200">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/tests/LinkDotNet.StringBuilder.Benchmarks/LinkDotNet.StringBuilder.Benchmarks.csproj
+++ b/tests/LinkDotNet.StringBuilder.Benchmarks/LinkDotNet.StringBuilder.Benchmarks.csproj
@@ -9,11 +9,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageReference Update="SonarAnalyzer.CSharp" Version="10.5.0.109200">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\LinkDotNet.StringBuilder\LinkDotNet.StringBuilder.csproj" />
+        <ProjectReference Include="..\..\src\LinkDotNet.StringBuilder\LinkDotNet.StringBuilder.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/LinkDotNet.StringBuilder.Benchmarks/LinkDotNet.StringBuilder.Benchmarks.csproj
+++ b/tests/LinkDotNet.StringBuilder.Benchmarks/LinkDotNet.StringBuilder.Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -10,10 +10,6 @@
 
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-        <PackageReference Update="SonarAnalyzer.CSharp" Version="10.5.0.109200">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/LinkDotNet.StringBuilder.UnitTests/LinkDotNet.StringBuilder.UnitTests.csproj
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/LinkDotNet.StringBuilder.UnitTests.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="Shouldly" Version="4.3.0" />
         <PackageReference Include="xunit.v3" Version="1.0.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -30,7 +30,7 @@
     </ItemGroup>
 
     <ItemGroup Label="Global usings">
-        <Using Include="FluentAssertions" />
+        <Using Include="Shouldly" />
         <Using Include="Xunit" />
     </ItemGroup>
 

--- a/tests/LinkDotNet.StringBuilder.UnitTests/LinkDotNet.StringBuilder.UnitTests.csproj
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/LinkDotNet.StringBuilder.UnitTests.csproj
@@ -19,10 +19,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Update="SonarAnalyzer.CSharp" Version="10.5.0.109200">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/LinkDotNet.StringBuilder.UnitTests/LinkDotNet.StringBuilder.UnitTests.csproj
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/LinkDotNet.StringBuilder.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
@@ -8,21 +8,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="7.0.0" />
+        <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="xunit.v3" Version="1.0.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit.v3" Version="1.0.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.3">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Update="SonarAnalyzer.CSharp" Version="10.5.0.109200">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\LinkDotNet.StringBuilder\LinkDotNet.StringBuilder.csproj" />
+        <ProjectReference Include="..\..\src\LinkDotNet.StringBuilder\LinkDotNet.StringBuilder.csproj" />
     </ItemGroup>
 
     <ItemGroup Label="Global usings">

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Append.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Append.Tests.cs
@@ -11,7 +11,7 @@ public class ValueStringBuilderAppendTests
 
         stringBuilder.Append("That is a string");
 
-        stringBuilder.ToString().Should().Be("That is a string");
+        stringBuilder.ToString().ShouldBe("That is a string");
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class ValueStringBuilderAppendTests
         stringBuilder.Append("a");
         stringBuilder.Append("test");
 
-        stringBuilder.ToString().Should().Be("Thisisatest");
+        stringBuilder.ToString().ShouldBe("Thisisatest");
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class ValueStringBuilderAppendTests
 
         stringBuilder.Append(new string('c', 99));
 
-        stringBuilder.ToString().Should().MatchRegex("[c]{99}");
+        stringBuilder.ToString().ShouldMatch("[c]{99}");
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class ValueStringBuilderAppendTests
 
         stringBuilder.AppendLine("Hello");
 
-        stringBuilder.ToString().Should().Contain("Hello").And.Contain(Environment.NewLine);
+        stringBuilder.ToString().ShouldContain("Hello" + Environment.NewLine);
     }
 
     [Fact]
@@ -54,9 +54,9 @@ public class ValueStringBuilderAppendTests
 
         var returned = stringBuilder.AppendSpan(2);
 
-        stringBuilder.Length.Should().Be(2);
+        stringBuilder.Length.ShouldBe(2);
 
-        stringBuilder.ToString().Should().Be(returned.ToString());
+        stringBuilder.ToString().ShouldBe(returned.ToString());
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ValueStringBuilderAppendTests
 
         stringBuilder.AppendLine();
 
-        stringBuilder.ToString().Should().Be(Environment.NewLine);
+        stringBuilder.ToString().ShouldBe(Environment.NewLine);
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public class ValueStringBuilderAppendTests
 
         stringBuilder.Append("Hello");
 
-        stringBuilder[2].Should().Be('l');
+        stringBuilder[2].ShouldBe('l');
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class ValueStringBuilderAppendTests
 
         builder.Append(2.2f);
 
-        builder.ToString().Should().Be("2.2");
+        builder.ToString().ShouldBe("2.2");
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class ValueStringBuilderAppendTests
             builder.Append('c');
         }
 
-        builder.ToString().Should().MatchRegex("[c]{64}");
+        builder.ToString().ShouldMatch("[c]{64}");
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class ValueStringBuilderAppendTests
         builder.Append(1d / 3d);
         builder.Append(1d / 3d);
 
-        builder.ToString().Should().Be("0.33333333333333330.33333333333333330.3333333333333333");
+        builder.ToString().ShouldBe("0.33333333333333330.33333333333333330.3333333333333333");
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class ValueStringBuilderAppendTests
 
         builder.Append(Guid.Empty);
 
-        builder.ToString().Should().Be("00000000-0000-0000-0000-000000000000");
+        builder.ToString().ShouldBe("00000000-0000-0000-0000-000000000000");
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class ValueStringBuilderAppendTests
 
         builder.Append(value);
 
-        builder.ToString().Should().Be(expected);
+        builder.ToString().ShouldBe(expected);
     }
 
     [Fact]
@@ -165,7 +165,7 @@ public class ValueStringBuilderAppendTests
             builder.Append(pText, 5);
         }
 
-        builder.ToString().Should().Be("Hello");
+        builder.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class ValueStringBuilderAppendTests
 
         builder.Append(slice);
 
-        builder.ToString().Should().Be("ccccc");
+        builder.ToString().ShouldBe("ccccc");
     }
 
     [Fact]
@@ -189,7 +189,7 @@ public class ValueStringBuilderAppendTests
 
         builder.Trim();
 
-        builder.ToString().Should().Be("Hello World");
+        builder.ToString().ShouldBe("Hello World");
     }
 
     [Fact]
@@ -206,7 +206,7 @@ public class ValueStringBuilderAppendTests
 
         builder.Append(false);
 
-        builder.ToString().Should().NotBeNull();
+        builder.ToString().ShouldNotBeNull();
     }
 
     [Fact]
@@ -215,7 +215,7 @@ public class ValueStringBuilderAppendTests
         using var builder = new ValueStringBuilder();
         builder.Append('c');
 
-        builder.ToString().Should().Be("c");
+        builder.ToString().ShouldBe("c");
     }
 
     [Fact]
@@ -229,6 +229,6 @@ public class ValueStringBuilderAppendTests
         builder.Append(new string('e', 4096));
         builder.Append(new string('f', 8192));
 
-        builder.ToString().Should().MatchRegex("[a]{256}[b]{512}[c]{1024}[d]{2048}[e]{4096}[f]{8192}");
+        builder.ToString().ShouldMatch("[a]{256}[b]{512}[c]{1024}[d]{2048}[e]{4096}[f]{8192}");
     }
 }

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.AppendFormat.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.AppendFormat.Tests.cs
@@ -15,7 +15,7 @@ public class ValueStringBuilderAppendFormatTests
 
         builder.AppendFormat(format, arg);
 
-        builder.ToString().Should().Be(expected);
+        builder.ToString().ShouldBe(expected);
     }
 
     [Theory]
@@ -50,7 +50,7 @@ public class ValueStringBuilderAppendFormatTests
 
         builder.AppendFormat(format, arg1, arg2);
 
-        builder.ToString().Should().Be(expected);
+        builder.ToString().ShouldBe(expected);
     }
 
     [Theory]
@@ -64,7 +64,7 @@ public class ValueStringBuilderAppendFormatTests
 
         builder.AppendFormat(format, arg1, arg2, arg3);
 
-        builder.ToString().Should().Be(expected);
+        builder.ToString().ShouldBe(expected);
     }
 
     [Theory]
@@ -78,7 +78,7 @@ public class ValueStringBuilderAppendFormatTests
 
         builder.AppendFormat(format, arg1, arg2, arg3, arg4);
 
-        builder.ToString().Should().Be(expected);
+        builder.ToString().ShouldBe(expected);
     }
 
     [Theory]
@@ -92,6 +92,6 @@ public class ValueStringBuilderAppendFormatTests
 
         builder.AppendFormat(format, arg1, arg2, arg3, arg4, arg5);
 
-        builder.ToString().Should().Be(expected);
+        builder.ToString().ShouldBe(expected);
     }
 }

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.AppendJoin.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.AppendJoin.Tests.cs
@@ -29,7 +29,7 @@ public class ValueStringBuilderAppendJoinTests
 
         stringBuilder.AppendJoin(separator, values);
 
-        stringBuilder.ToString().Should().Be(expected);
+        stringBuilder.ToString().ShouldBe(expected);
     }
 
     [Theory]
@@ -40,7 +40,7 @@ public class ValueStringBuilderAppendJoinTests
 
         stringBuilder.AppendJoin(separator, values);
 
-        stringBuilder.ToString().Should().Be(expected);
+        stringBuilder.ToString().ShouldBe(expected);
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class ValueStringBuilderAppendJoinTests
 
         stringBuilder.AppendJoin(",", new object[] { 1, 1.05f });
 
-        stringBuilder.ToString().Should().Be("1,1.05");
+        stringBuilder.ToString().ShouldBe("1,1.05");
     }
 
     [Fact]
@@ -60,6 +60,6 @@ public class ValueStringBuilderAppendJoinTests
 
         stringBuilder.AppendJoin(',', new object[] { 1, 1.05f });
 
-        stringBuilder.ToString().Should().Be("1,1.05");
+        stringBuilder.ToString().ShouldBe("1,1.05");
     }
 }

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Insert.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Insert.Tests.cs
@@ -12,7 +12,7 @@ public class ValueStringBuilderInsertTests
 
         valueStringBuilder.Insert(6, "dear ");
 
-        valueStringBuilder.ToString().Should().Be("Hello dear World");
+        valueStringBuilder.ToString().ShouldBe("Hello dear World");
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public class ValueStringBuilderInsertTests
 
         valueStringBuilder.Insert(0, "Hello");
 
-        valueStringBuilder.ToString().Should().Be("Hello");
+        valueStringBuilder.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class ValueStringBuilderInsertTests
 
         builder.Insert(0, 2.2f);
 
-        builder.ToString().Should().Be("2.2");
+        builder.ToString().ShouldBe("2.2");
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class ValueStringBuilderInsertTests
 
         builder.Insert(0, Guid.Empty);
 
-        builder.ToString().Should().Be("00000000-0000-0000-0000-000000000000");
+        builder.ToString().ShouldBe("00000000-0000-0000-0000-000000000000");
     }
 
     [Fact]
@@ -142,6 +142,6 @@ public class ValueStringBuilderInsertTests
 
         builder.Insert(0, true);
 
-        builder.ToString().Should().Be("True");
+        builder.ToString().ShouldBe("True");
     }
 }

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Pad.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Pad.Tests.cs
@@ -9,7 +9,7 @@ public class ValueStringBuilderPadTests
 
         stringBuilder.PadLeft(10, ' ');
 
-        stringBuilder.ToString().Should().Be("     Hello");
+        stringBuilder.ToString().ShouldBe("     Hello");
     }
 
     [Fact]
@@ -19,7 +19,7 @@ public class ValueStringBuilderPadTests
 
         stringBuilder.PadRight(10, ' ');
 
-        stringBuilder.ToString().Should().Be("Hello     ");
+        stringBuilder.ToString().ShouldBe("Hello     ");
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class ValueStringBuilderPadTests
 
         stringBuilder.PadLeft(3, ' ');
 
-        stringBuilder.ToString().Should().Be("Hello");
+        stringBuilder.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -39,6 +39,6 @@ public class ValueStringBuilderPadTests
 
         stringBuilder.PadRight(3, ' ');
 
-        stringBuilder.ToString().Should().Be("Hello");
+        stringBuilder.ToString().ShouldBe("Hello");
     }
 }

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Replace.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Replace.Tests.cs
@@ -12,7 +12,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace('C', 'B');
 
-        builder.ToString().Should().MatchRegex("[B]{100}");
+        builder.ToString().ShouldMatch("[B]{100}");
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace('C', 'B', 1, 2);
 
-        builder.ToString().Should().Be("CBBC");
+        builder.ToString().ShouldBe("CBBC");
     }
 
     [Theory]
@@ -54,7 +54,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace("Hello", "Hallöchen");
 
-        builder.ToString().Should().Be("Hallöchen World. How are you doing. Hallöchen world examples are always fun.");
+        builder.ToString().ShouldBe("Hallöchen World. How are you doing. Hallöchen world examples are always fun.");
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace("Hello", "Ha");
 
-        builder.ToString().Should().Be("Ha World");
+        builder.ToString().ShouldBe("Ha World");
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace("Hello", "Hallöchen");
 
-        builder.ToString().Should().Be("Hallöchen World");
+        builder.ToString().ShouldBe("Hallöchen World");
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace("##Key##", "World");
 
-        builder.ToString().Should().Be("Hello World");
+        builder.ToString().ShouldBe("Hello World");
     }
 
     [Theory]
@@ -98,7 +98,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace(word, "Something");
 
-        builder.ToString().Should().Be(text);
+        builder.ToString().ShouldBe(text);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace("word", "word");
 
-        builder.ToString().Should().Be("text");
+        builder.ToString().ShouldBe("text");
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace("Test", "Not");
 
-        builder.ToString().Should().Be("Hello");
+        builder.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace("Hello", "Hallöchen", 0, 10);
 
-        builder.ToString().Should().Be("Hallöchen World. How are you doing. Hello world examples are always fun.");
+        builder.ToString().ShouldBe("Hallöchen World. How are you doing. Hello world examples are always fun.");
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.ReplaceGeneric("{0}", 1.2f);
 
-        builder.ToString().Should().Be("1.2");
+        builder.ToString().ShouldBe("1.2");
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.ReplaceGeneric("{0}", 1, 0, 6);
 
-        builder.ToString().Should().Be("11{0}");
+        builder.ToString().ShouldBe("11{0}");
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.ReplaceGeneric("{0}", default(MyStruct));
 
-        builder.ToString().Should().Be("Hello");
+        builder.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.ReplaceGeneric("{0}", default(MyStruct), 0, 6);
 
-        builder.ToString().Should().Be("HelloHello{0}");
+        builder.ToString().ShouldBe("HelloHello{0}");
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class ValueStringBuilderReplaceTests
 
         builder.Replace("A", "C");
 
-        builder.ToString().Should().MatchRegex("[CB]{100}");
+        builder.ToString().ShouldMatch("[CB]{100}");
     }
 
     private struct MyStruct

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Trim.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Trim.Tests.cs
@@ -14,7 +14,7 @@ public class ValueStringBuilderTrimTests
 
         valueStringBuilder.TrimStart();
 
-        valueStringBuilder.ToString().Should().Be(expected);
+        valueStringBuilder.ToString().ShouldBe(expected);
     }
 
     [Theory]
@@ -29,7 +29,7 @@ public class ValueStringBuilderTrimTests
 
         valueStringBuilder.TrimEnd();
 
-        valueStringBuilder.ToString().Should().Be(expected);
+        valueStringBuilder.ToString().ShouldBe(expected);
     }
 
     [Theory]
@@ -44,7 +44,7 @@ public class ValueStringBuilderTrimTests
 
         valueStringBuilder.Trim();
 
-        valueStringBuilder.ToString().Should().Be(expected);
+        valueStringBuilder.ToString().ShouldBe(expected);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class ValueStringBuilderTrimTests
 
         valueStringBuilder.TrimStart('H');
 
-        valueStringBuilder.ToString().Should().Be("eeHH");
+        valueStringBuilder.ToString().ShouldBe("eeHH");
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class ValueStringBuilderTrimTests
 
         valueStringBuilder.TrimEnd('H');
 
-        valueStringBuilder.ToString().Should().Be("HHee");
+        valueStringBuilder.ToString().ShouldBe("HHee");
     }
 
     [Fact]
@@ -77,6 +77,6 @@ public class ValueStringBuilderTrimTests
 
         valueStringBuilder.Trim('H');
 
-        valueStringBuilder.ToString().Should().Be("ee");
+        valueStringBuilder.ToString().ShouldBe("ee");
     }
 }

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilderExtensionsTests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilderExtensionsTests.cs
@@ -12,7 +12,7 @@ public class ValueStringBuilderExtensionsTests
 
         var fromBuilder = valueStringBuilder.ToStringBuilder().ToString();
 
-        fromBuilder.Should().Be("Hello");
+        fromBuilder.ShouldBe("Hello");
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class ValueStringBuilderExtensionsTests
 
         var toBuilder = stringBuilder.ToValueStringBuilder();
 
-        toBuilder.ToString().Should().Be("Hello");
+        toBuilder.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -33,6 +33,6 @@ public class ValueStringBuilderExtensionsTests
 
         Action act = () => sb.ToValueStringBuilder();
 
-        act.Should().Throw<ArgumentNullException>();
+        act.ShouldThrow<ArgumentNullException>();
     }
 }

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilderTests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilderTests.cs
@@ -32,8 +32,8 @@ public class ValueStringBuilderTests
 
         var result = stringBuilder.TryCopyTo(mySpan);
 
-        result.Should().BeTrue();
-        mySpan.ToString().Should().Be("Hello");
+        result.ShouldBeTrue();
+        mySpan.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public class ValueStringBuilderTests
 
         var output = stringBuilder.AsSpan().ToString();
 
-        output.Should().Be("Hello");
+        output.ShouldBe("Hello");
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class ValueStringBuilderTests
 
         var length = stringBuilder.Length;
 
-        length.Should().Be(5);
+        length.ShouldBe(5);
     }
 
     [Fact]
@@ -66,8 +66,8 @@ public class ValueStringBuilderTests
 
         stringBuilder.Clear();
 
-        stringBuilder.Length.Should().Be(0);
-        stringBuilder.ToString().Should().Be(string.Empty);
+        stringBuilder.Length.ShouldBe(0);
+        stringBuilder.ToString().ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class ValueStringBuilderTests
     {
         using var stringBuilder = new ValueStringBuilder();
 
-        stringBuilder.ToString().Should().Be(string.Empty);
+        stringBuilder.ToString().ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -86,8 +86,8 @@ public class ValueStringBuilderTests
 
         stringBuilder.Remove(0, 6);
 
-        stringBuilder.Length.Should().Be(5);
-        stringBuilder.ToString().Should().Be("World");
+        stringBuilder.Length.ShouldBe(5);
+        stringBuilder.ToString().ShouldBe("World");
     }
 
     [Theory]
@@ -120,7 +120,7 @@ public class ValueStringBuilderTests
 
         stringBuilder.Remove(0, 0);
 
-        stringBuilder.ToString().Should().Be("Hello");
+        stringBuilder.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -131,9 +131,9 @@ public class ValueStringBuilderTests
 
         fixed (char* c = stringBuilder)
         {
-            c[0].Should().Be('H');
-            c[1].Should().Be('e');
-            c[2].Should().Be('y');
+            c[0].ShouldBe('H');
+            c[1].ShouldBe('e');
+            c[2].ShouldBe('y');
         }
     }
 
@@ -145,7 +145,7 @@ public class ValueStringBuilderTests
 
         var index = stringBuilder.IndexOf("World");
 
-        index.Should().Be(6);
+        index.ShouldBe(6);
     }
 
     [Fact]
@@ -156,7 +156,7 @@ public class ValueStringBuilderTests
 
         var index = stringBuilder.IndexOf("l", 6);
 
-        index.Should().Be(3);
+        index.ShouldBe(3);
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public class ValueStringBuilderTests
 
         var index = stringBuilder.IndexOf("Mountain");
 
-        index.Should().Be(-1);
+        index.ShouldBe(-1);
     }
 
     [Fact]
@@ -213,7 +213,7 @@ public class ValueStringBuilderTests
 
         var index = stringBuilder.IndexOf(string.Empty);
 
-        index.Should().Be(0);
+        index.ShouldBe(0);
     }
 
     [Fact]
@@ -224,7 +224,7 @@ public class ValueStringBuilderTests
 
         var index = stringBuilder.IndexOf("Hello World but longer");
 
-        index.Should().Be(-1);
+        index.ShouldBe(-1);
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class ValueStringBuilderTests
 
         var index = stringBuilder.IndexOf("word");
 
-        index.Should().Be(-1);
+        index.ShouldBe(-1);
     }
 
     [Fact]
@@ -245,7 +245,7 @@ public class ValueStringBuilderTests
 
         builder.EnsureCapacity(128);
 
-        builder.Capacity.Should().Be(128);
+        builder.Capacity.ShouldBe(128);
     }
 
     [Fact]
@@ -256,7 +256,7 @@ public class ValueStringBuilderTests
 
         builder.EnsureCapacity(16);
 
-        builder.Length.Should().BeGreaterOrEqualTo(128);
+        builder.Length.ShouldBeGreaterThanOrEqualTo(128);
     }
 
     [Fact]
@@ -267,7 +267,7 @@ public class ValueStringBuilderTests
 
         var index = builder.LastIndexOf("Hello");
 
-        index.Should().Be(6);
+        index.ShouldBe(6);
     }
 
     [Fact]
@@ -278,7 +278,7 @@ public class ValueStringBuilderTests
 
         var index = builder.LastIndexOf("Hello", 6);
 
-        index.Should().Be(0);
+        index.ShouldBe(0);
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public class ValueStringBuilderTests
     {
         using var builder = new ValueStringBuilder("Hello");
 
-        builder.LastIndexOf("o").Should().Be(4);
+        builder.LastIndexOf("o").ShouldBe(4);
     }
 
     [Fact]
@@ -297,7 +297,7 @@ public class ValueStringBuilderTests
 
         var index = builder.IndexOf(string.Empty, 6);
 
-        index.Should().Be(0);
+        index.ShouldBe(0);
     }
 
     [Fact]
@@ -307,7 +307,7 @@ public class ValueStringBuilderTests
 
         var index = stringBuilder.LastIndexOf(string.Empty);
 
-        index.Should().Be(0);
+        index.ShouldBe(0);
     }
 
     [Fact]
@@ -318,7 +318,7 @@ public class ValueStringBuilderTests
 
         var index = builder.LastIndexOf(string.Empty, 6);
 
-        index.Should().Be(0);
+        index.ShouldBe(0);
     }
 
     [Theory]
@@ -332,7 +332,7 @@ public class ValueStringBuilderTests
 
         var index = builder.Contains(word);
 
-        index.Should().Be(expected);
+        index.ShouldBe(expected);
     }
 
     [Fact]
@@ -343,7 +343,7 @@ public class ValueStringBuilderTests
 
         builder.Append("Hello");
 
-        builder.ToString().Should().Be("Hello");
+        builder.ToString().ShouldBe("Hello");
     }
 
     [Fact]
@@ -361,7 +361,7 @@ public class ValueStringBuilderTests
     {
         var result = ValueStringBuilder.Concat("Hello", " ", "World");
 
-        result.Should().Be("Hello World");
+        result.ShouldBe("Hello World");
     }
 
     [Fact]
@@ -369,7 +369,7 @@ public class ValueStringBuilderTests
     {
         var result = ValueStringBuilder.Concat("Test", 1);
 
-        result.Should().Be("Test1");
+        result.ShouldBe("Test1");
     }
 
     [Fact]
@@ -377,7 +377,7 @@ public class ValueStringBuilderTests
     {
         var result = ValueStringBuilder.Concat("Test", 1, 2);
 
-        result.Should().Be("Test12");
+        result.ShouldBe("Test12");
     }
 
     [Fact]
@@ -385,7 +385,7 @@ public class ValueStringBuilderTests
     {
         var result = ValueStringBuilder.Concat("Test", 1, 2, 3);
 
-        result.Should().Be("Test123");
+        result.ShouldBe("Test123");
     }
 
     [Fact]
@@ -393,7 +393,7 @@ public class ValueStringBuilderTests
     {
         var result = ValueStringBuilder.Concat("Test", 1, 2, 3, 4);
 
-        result.Should().Be("Test1234");
+        result.ShouldBe("Test1234");
     }
 
     [Fact]
@@ -401,7 +401,7 @@ public class ValueStringBuilderTests
     {
         var result = new ValueStringBuilder("Hello World").ToString();
 
-        result.Should().Be("Hello World");
+        result.ShouldBe("Hello World");
     }
 
     [Fact]
@@ -409,7 +409,7 @@ public class ValueStringBuilderTests
     {
         var result = new ValueStringBuilder("Hello World").ToString(1, 3);
 
-        result.Should().Be("ell");
+        result.ShouldBe("ell");
     }
 
     [Fact]
@@ -417,7 +417,7 @@ public class ValueStringBuilderTests
     {
         using ValueStringBuilder sb = "Hello World";
 
-        sb.ToString().Should().Be("Hello World");
+        sb.ToString().ShouldBe("Hello World");
     }
 
     [Fact]
@@ -425,7 +425,7 @@ public class ValueStringBuilderTests
     {
         using ValueStringBuilder sb = "Hello World".AsSpan();
 
-        sb.ToString().Should().Be("Hello World");
+        sb.ToString().ShouldBe("Hello World");
     }
 
     [Fact]
@@ -433,7 +433,7 @@ public class ValueStringBuilderTests
     {
         var result = ValueStringBuilder.Concat("Hello", " ", "World");
 
-        result.Should().Be("Hello World");
+        result.ShouldBe("Hello World");
     }
 
     [Fact]
@@ -441,7 +441,7 @@ public class ValueStringBuilderTests
     {
         var result = ValueStringBuilder.Concat(Array.Empty<string>());
 
-        result.Should().Be(string.Empty);
+        result.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -449,7 +449,7 @@ public class ValueStringBuilderTests
     {
         var result = ValueStringBuilder.Concat(true, 1);
 
-        result.Should().Be("True1");
+        result.ShouldBe("True1");
     }
 
     [Theory]
@@ -461,7 +461,7 @@ public class ValueStringBuilderTests
 
         var isEqual = builder.Equals(input);
 
-        isEqual.Should().Be(expected);
+        isEqual.ShouldBe(expected);
     }
 
     [Fact]
@@ -469,7 +469,7 @@ public class ValueStringBuilderTests
     {
         string[]? array = null;
 
-        ValueStringBuilder.Concat(array!).Should().Be(string.Empty);
+        ValueStringBuilder.Concat(array!).ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -479,7 +479,7 @@ public class ValueStringBuilderTests
 
         builder.Reverse();
 
-        builder.ToString().Should().Be("olleH");
+        builder.ToString().ShouldBe("olleH");
     }
 
     [Fact]
@@ -487,7 +487,7 @@ public class ValueStringBuilderTests
     {
         using var builder = new ValueStringBuilder("Hello World");
 
-        builder.ToString(1..4).Should().Be("ell");
+        builder.ToString(1..4).ShouldBe("ell");
     }
 
     [Fact]
@@ -501,7 +501,7 @@ public class ValueStringBuilderTests
             output += c;
         }
 
-        output.Should().Be("Hello World");
+        output.ShouldBe("Hello World");
     }
 
     [Fact]
@@ -511,7 +511,7 @@ public class ValueStringBuilderTests
 
         builder.Dispose();
 
-        builder.ToString().Should().Be(string.Empty);
+        builder.ToString().ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -519,6 +519,6 @@ public class ValueStringBuilderTests
     {
         using var builder = new ValueStringBuilder(128);
 
-        builder.Capacity.Should().Be(128);
+        builder.Capacity.ShouldBe(128);
     }
 }


### PR DESCRIPTION
This pull request updates all the packages to their latest versions, but the second commit also replaces [FluentAssertions](https://github.com/fluentassertions/fluentassertions) with [Shouldly](https://github.com/shouldly/shouldly).

If you didn't know, FluentAssertions v8 changed their [license](https://github.com/fluentassertions/fluentassertions/blob/main/LICENSE) so that it's no longer open-source (previously Apache-2.0). The new license requires you pay [$130](https://xceed.com/products/unit-testing/fluent-assertions) per seat for commercial use. So I migrated the tests in this library to [Shouldly](https://github.com/shouldly/shouldly), a similar library under BSD-3-clause. I haven't used it before but it seems more consistent from what I can see.

Alternatively, you could continue using FluentAssertions v7 and pin it at `[7.0.0]` (or `[7.1.0]`). Up to you!