### PR TITLE
Add insert & replace methods for runes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to **ValueStringBuilder** will be documented in this file. T
 
 - Added `TrimPrefix(ReadOnlySpan<char>, StringComparison)` (by yours truly (@Joy-less) in #226)
 - Added `TrimSuffix(ReadOnlySpan<char>, StringComparison)` (also by yours truly (@Joy-less) in #226)
+- Added `Insert(int, char)` overload (by yours truly (@Joy-less) in #225)
+- Added `Insert(int, Rune)` overload (again by yours truly (@Joy-less) in #225)
+- Added `Replace(Rune, Rune)` overload (see yours truly (@Joy-less) in #225)
+- Improved `Replace(scoped ReadOnlySpan<char>, scoped ReadOnlySpan<char>, int, int)` fallback (achieved by yours truly (@Joy-less) in #225)
 
 ## [2.1.0] - 2025-01-14
 

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
@@ -126,10 +126,10 @@ public ref partial struct ValueStringBuilder
     public void Append(Rune value)
     {
         Span<char> valueChars = stackalloc char[2];
-        int valueCharsWritten = value.EncodeToUtf16(valueChars);
-        ReadOnlySpan<char> valueCharsReadOnly = valueChars[..valueCharsWritten];
+        var valueCharsWritten = value.EncodeToUtf16(valueChars);
+        ReadOnlySpan<char> valueCharsSlice = valueChars[..valueCharsWritten];
 
-        Append(valueCharsReadOnly);
+        Append(valueCharsSlice);
     }
 
     /// <summary>

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Insert.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Insert.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace LinkDotNet.StringBuilder;
 
@@ -11,6 +12,29 @@ public ref partial struct ValueStringBuilder
     /// <param name="value">Boolean to insert into this builder.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Insert(int index, bool value) => Insert(index, value.ToString());
+
+    /// <summary>
+    /// Insert the string representation of the character to the builder at the given index.
+    /// </summary>
+    /// <param name="index">Index where <paramref name="value"/> should be inserted.</param>
+    /// <param name="value">Character to insert into this builder.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Insert(int index, char value) => Insert(index, [value]);
+
+    /// <summary>
+    /// Insert the string representation of the rune to the builder at the given index.
+    /// </summary>
+    /// <param name="index">Index where <paramref name="value"/> should be inserted.</param>
+    /// <param name="value">Rune to insert into this builder.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Insert(int index, Rune value)
+    {
+        Span<char> valueChars = stackalloc char[2];
+        int valueCharsWritten = value.EncodeToUtf16(valueChars);
+        ReadOnlySpan<char> valueCharsReadOnly = valueChars[..valueCharsWritten];
+
+        Insert(index, valueCharsReadOnly);
+    }
 
     /// <summary>
     /// Insert the string representation of the char to the builder at the given index.

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Insert.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Insert.cs
@@ -30,10 +30,10 @@ public ref partial struct ValueStringBuilder
     public void Insert(int index, Rune value)
     {
         Span<char> valueChars = stackalloc char[2];
-        int valueCharsWritten = value.EncodeToUtf16(valueChars);
-        ReadOnlySpan<char> valueCharsReadOnly = valueChars[..valueCharsWritten];
+        var valueCharsWritten = value.EncodeToUtf16(valueChars);
+        ReadOnlySpan<char> valueCharsSlice = valueChars[..valueCharsWritten];
 
-        Insert(index, valueCharsReadOnly);
+        Insert(index, valueCharsSlice);
     }
 
     /// <summary>

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
@@ -14,17 +14,6 @@ public ref partial struct ValueStringBuilder
     public readonly void Replace(char oldValue, char newValue) => Replace(oldValue, newValue, 0, Length);
 
     /// <summary>
-    /// Replaces all instances of one rune with another in this builder.
-    /// </summary>
-    /// <param name="oldValue">The rune to replace.</param>
-    /// <param name="newValue">The rune to replace <paramref name="oldValue"/> with.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Replace(Rune oldValue, Rune newValue)
-    {
-        Replace(oldValue, newValue, 0, Length);
-    }
-
-    /// <summary>
     /// Replaces all instances of one character with another in this builder.
     /// </summary>
     /// <param name="oldValue">The character to replace.</param>
@@ -34,15 +23,8 @@ public ref partial struct ValueStringBuilder
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly void Replace(char oldValue, char newValue, int startIndex, int count)
     {
-        if (startIndex < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(startIndex), "Start index can't be smaller than 0.");
-        }
-
-        if (count > bufferPosition)
-        {
-            throw new ArgumentOutOfRangeException(nameof(count), $"Count: {count} is bigger than the current size {bufferPosition}.");
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 0);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex + count, Length);
 
         for (var i = startIndex; i < startIndex + count; i++)
         {
@@ -52,6 +34,14 @@ public ref partial struct ValueStringBuilder
             }
         }
     }
+
+    /// <summary>
+    /// Replaces all instances of one rune with another in this builder.
+    /// </summary>
+    /// <param name="oldValue">The rune to replace.</param>
+    /// <param name="newValue">The rune to replace <paramref name="oldValue"/> with.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Replace(Rune oldValue, Rune newValue) => Replace(oldValue, newValue, 0, Length);
 
     /// <summary>
     /// Replaces all instances of one rune with another in this builder.
@@ -99,6 +89,9 @@ public ref partial struct ValueStringBuilder
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Replace(scoped ReadOnlySpan<char> oldValue, scoped ReadOnlySpan<char> newValue, int startIndex, int count)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 0);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex + count, Length);
+
         var length = startIndex + count;
         var slice = buffer[startIndex..length];
 
@@ -188,7 +181,7 @@ public ref partial struct ValueStringBuilder
         }
         else
         {
-            Replace(oldValue, (ReadOnlySpan<char>)newValue?.ToString(), startIndex, count);
+            Replace(oldValue, (newValue?.ToString() ?? string.Empty).AsSpan(), startIndex, count);
         }
     }
 }

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
@@ -54,14 +54,14 @@ public ref partial struct ValueStringBuilder
     public void Replace(Rune oldValue, Rune newValue, int startIndex, int count)
     {
         Span<char> oldValueChars = stackalloc char[2];
-        int oldValueCharsWritten = oldValue.EncodeToUtf16(oldValueChars);
-        ReadOnlySpan<char> oldValueCharsReadOnly = oldValueChars[..oldValueCharsWritten];
+        var oldValueCharsWritten = oldValue.EncodeToUtf16(oldValueChars);
+        ReadOnlySpan<char> oldValueCharsSlice = oldValueChars[..oldValueCharsWritten];
 
         Span<char> newValueChars = stackalloc char[2];
-        int newValueCharsWritten = newValue.EncodeToUtf16(newValueChars);
-        ReadOnlySpan<char> newValueCharsReadOnly = newValueChars[..newValueCharsWritten];
+        var newValueCharsWritten = newValue.EncodeToUtf16(newValueChars);
+        ReadOnlySpan<char> newValueCharsSlice = newValueChars[..newValueCharsWritten];
 
-        Replace(oldValueCharsReadOnly, newValueCharsReadOnly, startIndex, count);
+        Replace(oldValueCharsSlice, newValueCharsSlice, startIndex, count);
     }
 
     /// <summary>


### PR DESCRIPTION
Adds:
- `Insert(int, char)`
- `Insert(int, Rune)`
- `Replace(Rune, Rune)`
- Improves `Replace(scoped ReadOnlySpan<char>, scoped ReadOnlySpan<char>, int, int)`

As I was making this I was left a bit confused by `ReplaceGeneric`. I wasn't sure why it was called that instead of just `Replace`. Especially considering `Insert` has a generic overload that does the same thing just without the `ToString` fallback.