### PR TITLE
Add TrimPrefix and TrimSuffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to **ValueStringBuilder** will be documented in this file. T
 
 ## [Unreleased]
 
+### Added
+
+- Added `TrimPrefix(ReadOnlySpan<char>, StringComparison)` (by yours truly (@Joy-less) in #226)
+- Added `TrimSuffix(ReadOnlySpan<char>, StringComparison)` (also by yours truly (@Joy-less) in #226)
+
 ## [2.1.0] - 2025-01-14
 
 ### Added

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Trim.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Trim.cs
@@ -5,7 +5,7 @@ namespace LinkDotNet.StringBuilder;
 public ref partial struct ValueStringBuilder
 {
     /// <summary>
-    /// Removes a set of whitespace characters from the beginning and ending of this string.
+    /// Removes all whitespace characters from the start and end of this builder.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Trim()
@@ -33,22 +33,22 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Removes the specified character from the beginning and end of this string.
+    /// Removes all occurrences of the specified character from the start and end of this builder.
     /// </summary>
-    /// <param name="c">The character to remove.</param>
+    /// <param name="value">The character to remove.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Trim(char c)
+    public void Trim(char value)
     {
         // Remove character from the beginning
         var start = 0;
-        while (start < bufferPosition && buffer[start] == c)
+        while (start < bufferPosition && buffer[start] == value)
         {
             start++;
         }
 
         // Remove character from the end
         var end = bufferPosition - 1;
-        while (end >= start && buffer[end] == c)
+        while (end >= start && buffer[end] == value)
         {
             end--;
         }
@@ -62,7 +62,7 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Removes a set of whitespace characters from the beginning of this string.
+    /// Removes all whitespace characters from the start of this builder.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void TrimStart()
@@ -82,14 +82,14 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Removes the specified character from the beginning of this string.
+    /// Removes all occurrences of the specified character from the start of this builder.
     /// </summary>
-    /// <param name="c">The character to remove.</param>
+    /// <param name="value">The character to remove.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void TrimStart(char c)
+    public void TrimStart(char value)
     {
         var start = 0;
-        while (start < bufferPosition && buffer[start] == c)
+        while (start < bufferPosition && buffer[start] == value)
         {
             start++;
         }
@@ -103,7 +103,7 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Removes a set of whitespace characters from the ending of this string.
+    /// Removes all whitespace characters from the end of this builder.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void TrimEnd()
@@ -118,18 +118,46 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Removes the specified character from the end of this string.
+    /// Removes all occurrences of the specified character from the end of this builder.
     /// </summary>
-    /// <param name="c">The character to remove.</param>
+    /// <param name="value">The character to remove.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void TrimEnd(char c)
+    public void TrimEnd(char value)
     {
         var end = bufferPosition - 1;
-        while (end >= 0 && buffer[end] == c)
+        while (end >= 0 && buffer[end] == value)
         {
             end--;
         }
 
         bufferPosition = end + 1;
+    }
+
+    /// <summary>
+    /// Removes the specified sequence of characters from the start of this builder.
+    /// </summary>
+    /// <param name="value">The sequence of characters to remove.</param>
+    /// <param name="comparisonType">The way to compare the sequences of characters.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void TrimPrefix(ReadOnlySpan<char> value, StringComparison comparisonType = StringComparison.Ordinal)
+    {
+        if (AsSpan().StartsWith(value, comparisonType))
+        {
+            Remove(0, value.Length);
+        }
+    }
+
+    /// <summary>
+    /// Removes the specified sequence of characters from the end of this builder.
+    /// </summary>
+    /// <param name="value">The sequence of characters to remove.</param>
+    /// <param name="comparisonType">The way to compare the sequences of characters.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void TrimSuffix(ReadOnlySpan<char> value, StringComparison comparisonType = StringComparison.Ordinal)
+    {
+        if (AsSpan().EndsWith(value, comparisonType))
+        {
+            Remove(Length - value.Length, value.Length);
+        }
     }
 }

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
@@ -199,24 +199,13 @@ public ref partial struct ValueStringBuilder
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Remove(int startIndex, int length)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(length, 0);
+        ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 0);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex + length, Length);
+
         if (length == 0)
         {
             return;
-        }
-
-        if (length < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(length), "The given length can't be negative.");
-        }
-
-        if (startIndex < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(startIndex), "The given start index can't be negative.");
-        }
-
-        if (length > Length - startIndex)
-        {
-            throw new ArgumentOutOfRangeException(nameof(length), $"The given Span ({startIndex}..{length})length is outside the the represented string.");
         }
 
         var beginIndex = startIndex + length;

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Trim.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Trim.Tests.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace LinkDotNet.StringBuilder.UnitTests;
 
 public class ValueStringBuilderTrimTests
@@ -86,7 +88,7 @@ public class ValueStringBuilderTrimTests
         using var valueStringBuilder = new ValueStringBuilder();
         valueStringBuilder.Append("Hello world");
 
-        valueStringBuilder.TrimPrefix("hell", System.StringComparison.InvariantCultureIgnoreCase);
+        valueStringBuilder.TrimPrefix("hell", StringComparison.InvariantCultureIgnoreCase);
 
         valueStringBuilder.ToString().ShouldBe("o world");
     }
@@ -97,7 +99,7 @@ public class ValueStringBuilderTrimTests
         using var valueStringBuilder = new ValueStringBuilder();
         valueStringBuilder.Append("Hello world");
 
-        valueStringBuilder.TrimPrefix("RlD", System.StringComparison.InvariantCultureIgnoreCase);
+        valueStringBuilder.TrimSuffix("RlD", StringComparison.InvariantCultureIgnoreCase);
 
         valueStringBuilder.ToString().ShouldBe("Hello wo");
     }

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Trim.Tests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilder.Trim.Tests.cs
@@ -79,4 +79,26 @@ public class ValueStringBuilderTrimTests
 
         valueStringBuilder.ToString().ShouldBe("ee");
     }
+
+    [Fact]
+    public void GivenString_WhenTrimPrefix_ThenShouldRemoveSpan()
+    {
+        using var valueStringBuilder = new ValueStringBuilder();
+        valueStringBuilder.Append("Hello world");
+
+        valueStringBuilder.TrimPrefix("hell", System.StringComparison.InvariantCultureIgnoreCase);
+
+        valueStringBuilder.ToString().ShouldBe("o world");
+    }
+
+    [Fact]
+    public void GivenString_WhenTrimSuffix_ThenShouldRemoveSpan()
+    {
+        using var valueStringBuilder = new ValueStringBuilder();
+        valueStringBuilder.Append("Hello world");
+
+        valueStringBuilder.TrimPrefix("RlD", System.StringComparison.InvariantCultureIgnoreCase);
+
+        valueStringBuilder.ToString().ShouldBe("Hello wo");
+    }
 }


### PR DESCRIPTION
Adds:
- `TrimPrefix(ReadOnlySpan<char>, StringComparison)`
- `TrimSuffix(ReadOnlySpan<char>, StringComparison)`
- Relevant unit tests

These are basically the same as `TrimStart` and `TrimEnd` but they remove a single string instead of every occurrence of a character.