### PR TITLE
Add IDisposable to ValueStringBuilder

### DIFF
--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
@@ -5,15 +5,15 @@ using System.Runtime.InteropServices;
 namespace LinkDotNet.StringBuilder;
 
 /// <summary>
-/// Represents a string builder which tried to reduce as much allocations as possible.
+/// A string builder which minimizes as many heap allocations as possible.
 /// </summary>
 /// <remarks>
-/// The <see cref="ValueStringBuilder"/> is declared as ref struct which brings certain limitations with it.
-/// You can only use it in another ref struct or as a local variable.
+/// This is a ref struct which has certain limitations.
+/// You can only store it in a local variable or another ref struct.
 /// </remarks>
 [StructLayout(LayoutKind.Sequential)]
 [SkipLocalsInit]
-public ref partial struct ValueStringBuilder
+public ref partial struct ValueStringBuilder : IDisposable
 {
     private int bufferPosition;
     private Span<char> buffer;

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
@@ -8,8 +8,8 @@ namespace LinkDotNet.StringBuilder;
 /// A string builder which minimizes as many heap allocations as possible.
 /// </summary>
 /// <remarks>
-/// This is a ref struct which has certain limitations.
-/// You can only store it in a local variable or another ref struct.
+/// This is a ref struct which has certain limitations. You can only store it in a local variable or another ref struct.<br/><br/>
+/// You should dispose it after use to ensure the rented buffer is returned to the array pool.
 /// </remarks>
 [StructLayout(LayoutKind.Sequential)]
 [SkipLocalsInit]
@@ -294,7 +294,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     public readonly bool Equals(ReadOnlySpan<char> span) => span.SequenceEqual(AsSpan());
 
     /// <summary>
-    /// Disposes the instance and returns rented buffer from an array pool if needed.
+    /// Disposes the instance and returns the rented buffer to the array pool if needed.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()


### PR DESCRIPTION
This adds the `IDisposable` interface to `ValueStringBuilder` to make it clear that it can be disposed, and says it in the documentation comments as well.