### PR TITLE
Minor `Replace` optimization?

### DIFF
--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
@@ -97,6 +97,12 @@ public ref partial struct ValueStringBuilder
             return;
         }
 
+        if (oldValue.Length == 1 && newValue.Length == 1)
+        {
+            Replace(oldValue[0], newValue[1], startIndex, count);
+            return;
+        }
+
         var index = startIndex;
         var remainingChars = count;
 


### PR DESCRIPTION
This is a minor optimization for `Replace` that checks if `oldValue` and `newValue` are both of length 1, if so then it uses the `Replace(char, char)` overload.

I was mainly thinking in terms of `Replace(Rune, Rune)` where runes are usually part of the BMP range.