### PR TITLE
Optimize & simplify `Replace(char, char)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to **ValueStringBuilder** will be documented in this file. T
 
 ## [Unreleased]
 
+### Changed
+
+- Optimized `Replace(char, char)` (by @Joy-less in #241)
+- Optimized `Replace(ReadOnlySpan<char>, ReadOnlySpan<char>)` when both spans are length 1 (by @Joy-less in #241)
+
 ## [2.4.0] - 2025-02-21
 
 ### Added

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
@@ -91,6 +91,12 @@ public ref partial struct ValueStringBuilder
             return;
         }
 
+        if (oldValue.Length == 1 && newValue.Length == 1)
+        {
+            Replace(oldValue[0], newValue[0], startIndex, count);
+            return;
+        }
+
         var index = startIndex;
         var remainingChars = count;
 

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Replace.cs
@@ -26,13 +26,7 @@ public ref partial struct ValueStringBuilder
         ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 0);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex + count, Length);
 
-        for (var i = startIndex; i < startIndex + count; i++)
-        {
-            if (buffer[i] == oldValue)
-            {
-                buffer[i] = newValue;
-            }
-        }
+        buffer.Slice(startIndex, count).Replace(oldValue, newValue);
     }
 
     /// <summary>

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilderExtensions.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilderExtensions.cs
@@ -29,7 +29,7 @@ public static class ValueStringBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var valueStringBuilder = new ValueStringBuilder();
+        var valueStringBuilder = new ValueStringBuilder(builder.Length);
         foreach (var chunk in builder.GetChunks())
         {
             valueStringBuilder.Append(chunk.Span);


### PR DESCRIPTION
This PR does two things:
1. Simplifies & optimizes `Replace(char, char)`. The built-in logic has low level optimizations on the buffer.
2. Optimizes `ToValueStringBuilder(this StringBuilder)` by passing setting the initial capacity to avoid growing the buffer.

They're one PR because I was too lazy to make two.