### PR TITLE
Add `scoped` everywhere

### DIFF
--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Append.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -54,7 +54,7 @@ public ref partial struct ValueStringBuilder
     /// requires more space than the default (36 characters), adjust the value.</param>
     /// <typeparam name="T">Any <see cref="ISpanFormattable"/>.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Append<T>(T value, ReadOnlySpan<char> format = default, int bufferSize = 36)
+    public void Append<T>(T value, scoped ReadOnlySpan<char> format = default, int bufferSize = 36)
         where T : ISpanFormattable => AppendSpanFormattable(value, format, bufferSize);
 
     /// <summary>
@@ -181,7 +181,7 @@ public ref partial struct ValueStringBuilder
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void AppendSpanFormattable<T>(T value, ReadOnlySpan<char> format = default, int bufferSize = 36)
+    private void AppendSpanFormattable<T>(T value, scoped ReadOnlySpan<char> format = default, int bufferSize = 36)
         where T : ISpanFormattable
     {
         var newSize = bufferSize + bufferPosition;

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.AppendFormat.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.AppendFormat.cs
@@ -17,7 +17,7 @@ public ref partial struct ValueStringBuilder
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendFormat<T>(
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] ReadOnlySpan<char> format,
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] scoped ReadOnlySpan<char> format,
         T arg)
     {
         var formatIndex = 0;
@@ -73,7 +73,7 @@ public ref partial struct ValueStringBuilder
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendFormat<T1, T2>(
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] ReadOnlySpan<char> format,
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] scoped ReadOnlySpan<char> format,
         T1 arg1,
         T2 arg2)
     {
@@ -141,7 +141,7 @@ public ref partial struct ValueStringBuilder
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendFormat<T1, T2, T3>(
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] ReadOnlySpan<char> format,
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] scoped ReadOnlySpan<char> format,
         T1 arg1,
         T2 arg2,
         T3 arg3)
@@ -215,7 +215,7 @@ public ref partial struct ValueStringBuilder
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendFormat<T1, T2, T3, T4>(
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] ReadOnlySpan<char> format,
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] scoped ReadOnlySpan<char> format,
         T1 arg1,
         T2 arg2,
         T3 arg3,
@@ -295,7 +295,7 @@ public ref partial struct ValueStringBuilder
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendFormat<T1, T2, T3, T4, T5>(
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] ReadOnlySpan<char> format,
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] scoped ReadOnlySpan<char> format,
         T1 arg1,
         T2 arg2,
         T3 arg3,
@@ -360,7 +360,7 @@ public ref partial struct ValueStringBuilder
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int GetValidArgumentIndex(ReadOnlySpan<char> placeholder, int allowedRange)
+    private static int GetValidArgumentIndex(scoped ReadOnlySpan<char> placeholder, int allowedRange)
     {
         if (!int.TryParse(placeholder[1..^1], null, out var argIndex))
         {

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.AppendJoin.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.AppendJoin.cs
@@ -20,7 +20,7 @@ public ref partial struct ValueStringBuilder
     /// <param name="separator">String used as separator between the entries.</param>
     /// <param name="values">Enumerable of strings to be concatenated.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AppendJoin(ReadOnlySpan<char> separator, ReadOnlySpan<string?> values)
+    public void AppendJoin(ReadOnlySpan<char> separator, scoped ReadOnlySpan<string?> values)
         => AppendJoinInternalString(separator, values);
 
     /// <summary>
@@ -29,7 +29,7 @@ public ref partial struct ValueStringBuilder
     /// <param name="separator">Character used as separator between the entries.</param>
     /// <param name="values">Enumerable of strings to be concatenated.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AppendJoin(char separator, ReadOnlySpan<string?> values)
+    public void AppendJoin(char separator, scoped ReadOnlySpan<string?> values)
         => AppendJoinInternalChar(separator, values);
 
     /// <summary>
@@ -57,7 +57,7 @@ public ref partial struct ValueStringBuilder
     /// <param name="values">Enumerable to be concatenated.</param>
     /// <typeparam name="T">Type of the given enumerable.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AppendJoin<T>(ReadOnlySpan<char> separator, IEnumerable<T> values)
+    public void AppendJoin<T>(scoped ReadOnlySpan<char> separator, IEnumerable<T> values)
         => AppendJoinInternalString(separator, values);
 
     /// <summary>
@@ -67,7 +67,7 @@ public ref partial struct ValueStringBuilder
     /// <param name="values">Enumerable to be concatenated.</param>
     /// <typeparam name="T">Type of the given enumerable.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AppendJoin<T>(ReadOnlySpan<char> separator, ReadOnlySpan<T> values)
+    public void AppendJoin<T>(scoped ReadOnlySpan<char> separator, ReadOnlySpan<T> values)
         => AppendJoinInternalString(separator, values);
 
     /// <summary>
@@ -87,7 +87,7 @@ public ref partial struct ValueStringBuilder
     /// <param name="values">Enumerable to be concatenated.</param>
     /// <typeparam name="T">Type of the given enumerable.</typeparam>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AppendJoin<T>(char separator, ReadOnlySpan<T> values)
+    public void AppendJoin<T>(char separator, scoped ReadOnlySpan<T> values)
         => AppendJoinInternalChar(separator, values);
 
     /// <summary>
@@ -101,7 +101,7 @@ public ref partial struct ValueStringBuilder
         => AppendJoinInternalRune(separator, values);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void AppendJoinInternalString<T>(ReadOnlySpan<char> separator, IEnumerable<T> values)
+    private void AppendJoinInternalString<T>(scoped ReadOnlySpan<char> separator, IEnumerable<T> values)
     {
         ArgumentNullException.ThrowIfNull(values);
 
@@ -124,7 +124,7 @@ public ref partial struct ValueStringBuilder
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void AppendJoinInternalString<T>(ReadOnlySpan<char> separator, ReadOnlySpan<T> values)
+    private void AppendJoinInternalString<T>(scoped ReadOnlySpan<char> separator, scoped ReadOnlySpan<T> values)
     {
         if (values.Length == 0)
         {
@@ -164,7 +164,7 @@ public ref partial struct ValueStringBuilder
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void AppendJoinInternalChar<T>(char separator, ReadOnlySpan<T> values)
+    private void AppendJoinInternalChar<T>(char separator, scoped ReadOnlySpan<T> values)
     {
         if (values.Length == 0)
         {

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Concat.Helper.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Concat.Helper.cs
@@ -11,7 +11,7 @@ public ref partial struct ValueStringBuilder
     /// <typeparam name="T">Any given type, which can be translated to <see cref="string"/>.</typeparam>
     /// <returns>Concatenated string or an empty string if <paramref name="values"/> is empty.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string Concat<T>(params ReadOnlySpan<T> values)
+    public static string Concat<T>(params scoped ReadOnlySpan<T> values)
     {
         if (values.Length == 0)
         {

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Trim.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Trim.cs
@@ -139,7 +139,7 @@ public ref partial struct ValueStringBuilder
     /// <param name="value">The sequence of characters to remove.</param>
     /// <param name="comparisonType">The way to compare the sequences of characters.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void TrimPrefix(ReadOnlySpan<char> value, StringComparison comparisonType = StringComparison.Ordinal)
+    public void TrimPrefix(scoped ReadOnlySpan<char> value, StringComparison comparisonType = StringComparison.Ordinal)
     {
         if (AsSpan().StartsWith(value, comparisonType))
         {
@@ -153,7 +153,7 @@ public ref partial struct ValueStringBuilder
     /// <param name="value">The sequence of characters to remove.</param>
     /// <param name="comparisonType">The way to compare the sequences of characters.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void TrimSuffix(ReadOnlySpan<char> value, StringComparison comparisonType = StringComparison.Ordinal)
+    public void TrimSuffix(scoped ReadOnlySpan<char> value, StringComparison comparisonType = StringComparison.Ordinal)
     {
         if (AsSpan().EndsWith(value, comparisonType))
         {

--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.cs
@@ -46,7 +46,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// </summary>
     /// <param name="initialText">The initial text used to initialize this instance.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ValueStringBuilder(ReadOnlySpan<char> initialText)
+    public ValueStringBuilder(scoped ReadOnlySpan<char> initialText)
     {
         Append(initialText);
     }
@@ -110,7 +110,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// <param name="fromString">The string as initial buffer.</param>
 #pragma warning disable CA2225
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator ValueStringBuilder(ReadOnlySpan<char> fromString) => new(fromString);
+    public static implicit operator ValueStringBuilder(scoped ReadOnlySpan<char> fromString) => new(fromString);
 #pragma warning restore CA2225
 
     /// <summary>
@@ -251,7 +251,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// <param name="comparisonType">One of the enumeration values that specifies the rules for the search.</param>
     /// <returns>The index of the found <paramref name="word"/> in this string or -1 if not found.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int IndexOf(ReadOnlySpan<char> word, StringComparison comparisonType = StringComparison.Ordinal) => IndexOf(word, 0, comparisonType);
+    public readonly int IndexOf(scoped ReadOnlySpan<char> word, StringComparison comparisonType = StringComparison.Ordinal) => IndexOf(word, 0, comparisonType);
 
     /// <summary>
     /// Returns the index within this string of the first occurrence of the specified substring, starting at the specified index.
@@ -261,7 +261,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// <param name="comparisonType">One of the enumeration values that specifies the rules for the search.</param>
     /// <returns>The index of the found <paramref name="word"/> in this string or -1 if not found.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int IndexOf(ReadOnlySpan<char> word, int startIndex, StringComparison comparisonType = StringComparison.Ordinal)
+    public readonly int IndexOf(scoped ReadOnlySpan<char> word, int startIndex, StringComparison comparisonType = StringComparison.Ordinal)
     {
         return buffer[startIndex..bufferPosition].IndexOf(word, comparisonType);
     }
@@ -273,7 +273,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// <param name="comparisonType">One of the enumeration values that specifies the rules for the search.</param>
     /// <returns>The index of the found <paramref name="word"/> in this string or -1 if not found.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int LastIndexOf(ReadOnlySpan<char> word, StringComparison comparisonType = StringComparison.Ordinal) => LastIndexOf(word, 0, comparisonType);
+    public readonly int LastIndexOf(scoped ReadOnlySpan<char> word, StringComparison comparisonType = StringComparison.Ordinal) => LastIndexOf(word, 0, comparisonType);
 
     /// <summary>
     /// Returns the index within this string of the last occurrence of the specified substring, starting at the specified index.
@@ -283,7 +283,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// <param name="comparisonType">One of the enumeration values that specifies the rules for the search.</param>
     /// <returns>The index of the found <paramref name="word"/> in this string or -1 if not found.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int LastIndexOf(ReadOnlySpan<char> word, int startIndex, StringComparison comparisonType = StringComparison.Ordinal)
+    public readonly int LastIndexOf(scoped ReadOnlySpan<char> word, int startIndex, StringComparison comparisonType = StringComparison.Ordinal)
     {
         return buffer[startIndex..bufferPosition].LastIndexOf(word, comparisonType);
     }
@@ -298,7 +298,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// This method performs an ordinal (case-sensitive and culture-insensitive) comparison.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool Contains(ReadOnlySpan<char> word, StringComparison comparisonType = StringComparison.Ordinal) => IndexOf(word, comparisonType) != -1;
+    public readonly bool Contains(scoped ReadOnlySpan<char> word, StringComparison comparisonType = StringComparison.Ordinal) => IndexOf(word, comparisonType) != -1;
 
     /// <summary>
     /// Returns whether the characters in this builder are equal to the characters in the given span.
@@ -306,7 +306,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// <param name="span">The character span to compare with the current instance.</param>
     /// <returns><see langword="true"/> if the characters are equal to this instance, otherwise <see langword="false"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool Equals(ReadOnlySpan<char> span) => span.Equals(AsSpan(), StringComparison.Ordinal);
+    public readonly bool Equals(scoped ReadOnlySpan<char> span) => span.Equals(AsSpan(), StringComparison.Ordinal);
 
     /// <summary>
     /// Returns whether the characters in this builder are equal to the characters in the given span according to the given comparison type.
@@ -315,7 +315,7 @@ public ref partial struct ValueStringBuilder : IDisposable
     /// <param name="comparisonType">The way to compare the sequences of characters.</param>
     /// <returns><see langword="true"/> if the characters are equal to this instance, otherwise <see langword="false"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool Equals(ReadOnlySpan<char> span, StringComparison comparisonType) => span.Equals(AsSpan(), comparisonType);
+    public readonly bool Equals(scoped ReadOnlySpan<char> span, StringComparison comparisonType) => span.Equals(AsSpan(), comparisonType);
 
     /// <summary>
     /// Disposes the instance and returns the rented buffer to the array pool if needed.


### PR DESCRIPTION
Adds the `scoped` keyword everywhere to ensure that `stackalloc` is always able to be used. This is especially relevant fo `ValueStringBuilder(ReadOnlySpan<char> initialText)`.