### PR TITLE
Update documentation

### DIFF
--- a/articles/comparison.html
+++ b/articles/comparison.html
@@ -71,19 +71,18 @@
             <article class="content wrap" id="_content" data-uid="comparison">
 <h1 id="comparison">Comparison</h1>
 
-<p>The following document will show some key differences between the <code>ValueStringBuilder</code> and similar working string builder like the one from .NET itself.</p>
+<p>The following document shows some key differences between the <code>ValueStringBuilder</code> and the .NET <code>StringBuilder</code>.</p>
 <h2 id="systemtextstringbuilder">System.Text.StringBuilder</h2>
-<p>The <code>StringBuilder</code> shipped with the .NET Framework itself is a all-purpose string builder which allows a versatile use. <code>ValueStringBuilder</code> tries to mimic the API as much as possible so developers can adopt the <code>ValueStringBuilder</code> easily where it makes sense. In the following part <code>StringBuilder</code> refers to <code>System.Text.StringBuilder</code>.</p>
+<p><code>System.Text.StringBuilder</code> was created as an all-purpose string builder allowing versatile use. <code>ValueStringBuilder</code> mimics the API as much as possible so that developers can adopt the <code>ValueStringBuilder</code> easily. From now <code>System.Text.StringBuilder</code> will be referred to as <code>StringBuilder</code>.</p>
 <p><strong>Key differences</strong>:</p>
 <ul>
-<li><code>StringBuilder</code> is a class and does not have the restrictions coming with a <code>ref struct</code>. To know more head over to the <a class="xref" href="known_limitations.html">known limitations</a> section.</li>
-<li><code>StringBuilder</code> works not on <code>Span&lt;T&gt;</code> but more on <code>string</code>s or <code>char</code>s. Sometimes even with pointers</li>
-<li><code>StringBuilder</code> uses chunks to represent the string, which the larger the string gets, the better it can perform. <code>ValueStringBuilder</code> only has one internal <code>Span</code> as representation which can cause fragmentation on very big strings.</li>
-<li><code>StringBuilder</code> has a richer API as the <code>ValueStringBuilder</code>. In the future they should have the same amount of API's as the <code>StringBuilder</code> is the &quot;big brother&quot; of this package.</li>
-<li><code>ValueStringBuilder</code> has different API calls like <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilder.html#LinkDotNet_StringBuilder_ValueStringBuilder_IndexOf_ReadOnlySpan_System_Char__"><code>IndexOf</code></a> or <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilder.html#LinkDotNet_StringBuilder_ValueStringBuilder_LastIndexOf_ReadOnlySpan_System_Char__"><code>LastIndexOf</code></a>.</li>
+<li><code>StringBuilder</code> is a class and does not have the restrictions of a <code>ref struct</code>. To know more head over to the <a class="xref" href="known_limitations.html">Known Limitations</a>.</li>
+<li><code>StringBuilder</code> uses <code>char[]</code> arrays and pointers rather than <code>Span&lt;T&gt;</code>.
+<li><code>StringBuilder</code> uses chunks to represent the string, which allows large strings to be fragmented. <code>ValueStringBuilder</code> uses a single <code>Span</code> which prevents fragmentation.</li>
+<li><code>ValueStringBuilder</code> has additional methods like <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilder.html#LinkDotNet_StringBuilder_ValueStringBuilder_IndexOf_ReadOnlySpan_System_Char__"><code>IndexOf</code></a> and <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilder.html#LinkDotNet_StringBuilder_ValueStringBuilder_LastIndexOf_ReadOnlySpan_System_Char__"><code>LastIndexOf</code></a>.</li>
 </ul>
 <h2 id="benchmark">Benchmark</h2>
-<p>The following table gives you a small comparison between the <code>StringBuilder</code> which is part of .NET and the <code>ValueStringBuilder</code>:</p>
+<p>The following table gives you a small comparison between the built-in <code>StringBuilder</code> and <code>ValueStringBuilder</code>:</p>
 <pre><code>BenchmarkDotNet v0.14.0, macOS Sequoia 15.3.1 (24D70) [Darwin 24.3.0]
 Apple M2 Pro, 1 CPU, 12 logical and 12 physical cores
 .NET SDK 9.0.200
@@ -96,15 +95,14 @@ Apple M2 Pro, 1 CPU, 12 logical and 12 physical cores
 | DotNetStringBuilder | 126.74 ns | 0.714 ns | 0.667 ns |  1.00 | 0.1779 |    1488 B |        1.00 |
 | ValueStringBuilder  |  95.69 ns | 0.118 ns | 0.110 ns |  0.76 | 0.0669 |     560 B |        0.38 |
 </code></pre>
-<p>For more comparison check the documentation.</p>
-<p>Another benchmark shows that this <code>ValueStringBuilder</code> uses less memory when it comes to appending <code>ValueTypes</code> such as <code>int</code>, <code>double</code>, ...</p>
+<p>Another benchmark shows that <code>ValueStringBuilder</code> uses less memory when appending <code>ValueType</code>s such as <code>int</code> and <code>double</code> due to using <code>TryFormat</code> rather than <code>ToString</code> where possible.</p>
 <pre><code>| Method                         | Mean     | Error   | StdDev  | Gen0   | Gen1   | Allocated |
 |------------------------------- |---------:|--------:|--------:|-------:|-------:|----------:|
 | ValueStringBuilderAppendFormat | 821.7 ns | 1.29 ns | 1.14 ns | 0.4330 |      - |   3.54 KB |
 | StringBuilderAppendFormat      | 741.5 ns | 5.58 ns | 5.22 ns | 0.9909 | 0.0057 |    8.1 KB |
 
 </code></pre>
-<p>Checkout the <a href="https://github.com/linkdotnet/StringBuilder/tree/main/tests/LinkDotNet.StringBuilder.Benchmarks">Benchmark</a> for more detailed comparison and setup.</p>
+<p>Head over to the <a href="https://github.com/linkdotnet/StringBuilder/tree/main/tests/LinkDotNet.StringBuilder.Benchmarks">Benchmarks</a> to see the code.</p>
 </article>
           </div>
           

--- a/articles/concepts.html
+++ b/articles/concepts.html
@@ -71,10 +71,11 @@
             <article class="content wrap" id="_content" data-uid="">
 <h1 id="how-does-it-work">How does it work?</h1>
 
-<p>Before I answer the question, I would like to raise another question: How does it work differently and more effectively than the current <code>StringBuilder</code>?</p>
-<p>The basic idea is to use a <code>ref struct</code> which enforces that the <code>ValueStringBuilder</code> will live on the <strong>stack</strong> instead of the <strong>heap</strong>.
-Furthermore, we try to use advanced features like <code>Span&lt;T&gt;</code> and <code>ArrayPool</code> to reduce allocations even further. Because of the way C# / .NET is optimized for those types the <code>ValueStringBuilder</code> gains a lot of speed with low allocations.
-With this approach, some limitations arise. Head over to the <a class="xref" href="known_limitations.html">known limitation</a> to know more.</p>
+<p>Before I answer how it works, I would like to answer how it's more performant than the built-in <code>StringBuilder</code>?</p>
+<p>The basic idea is to use a <code>ref struct</code>. This ensures the <code>ValueStringBuilder</code> will live on the <strong>stack</strong> instead of the <strong>heap</strong>. This allows the use of stack-allocated <code>Span&lt;T&gt;</code> using <code>stackalloc</code>.
+Otherwise, it makes use of <code>ArrayPool</code> to reuse arrays.
+This allows <code>ValueStringBuilder</code> to gain performance with low allocations.
+With this approach, some limitations arise. Head over to the <a class="xref" href="known_limitations.html">Known Limitations</a> to know more.</p>
 <h2 id="resources">Resources:</h2>
 <p><a href="https://steven-giesel.com/blogPost/4cada9a7-c462-4133-ad7f-e8b671987896">Here</a> is my detailed blog post about some of the implementation details.</p>
 </article>

--- a/articles/getting_started.html
+++ b/articles/getting_started.html
@@ -72,7 +72,7 @@
 <h1 id="getting-started">Getting started</h1>
 
 <p>The following section will show you how to use the <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilder.html"><code>ValueStringBuilder</code></a>.</p>
-<p>For .NET 6 use the <a href="https://www.nuget.org/packages/LinkDotNet.StringBuilder/">nuget-package</a>:</p>
+<p>For .NET 8.0+ use the <a href="https://www.nuget.org/packages/LinkDotNet.StringBuilder/">nuget-package</a>:</p>
 <blockquote>
 <p>PM&gt; Install-Package LinkDotNet.StringBuilder</p>
 </blockquote>
@@ -85,7 +85,7 @@ public static class Program
 {
     public static void Main()
     {
-        var stringBuilder = new ValueStringBuilder();
+        using var stringBuilder = new ValueStringBuilder();
 
         stringBuilder.AppendLine(&quot;Hello World!&quot;);
         stringBuilder.Append(0.3f);
@@ -94,10 +94,9 @@ public static class Program
     }
 } 
 </code></pre>
-<p>Prints:
-<a href="https://dotnetfiddle.net/wM5r0q">Here</a> is an interactive example where you can fiddle around with the library. The example is hosted on <a href="https://dotnetfiddle.net/wM5r0q">https://dotnetfiddle.net/</a> and already has the <code>ValueStringBuilder</code> nuget package included in the latest version.</p>
+<p><a href="https://dotnetfiddle.net/wM5r0q">Here</a> is an interactive example where you can fiddle around with the library. The example is hosted on <a href="https://dotnetfiddle.net/EzdvAb">https://dotnetfiddle.net</a> and already has the latest <code>ValueStringBuilder</code> NuGet package installed.</p>
 <h2 id="helper-methods">Helper methods</h2>
-<p>There are also very easy-to-use helper methods, which doesn't need a <code>ValueStringBuilder</code> instance:</p>
+<p>There are also some static helper methods:</p>
 <pre><code class="lang-csharp">using LinkDotNet.StringBuilder;
 
 string helloWorld = ValueStringBuilder.Concat(&quot;Hello World!&quot;, 101);

--- a/articles/known_limitations.html
+++ b/articles/known_limitations.html
@@ -71,18 +71,18 @@
             <article class="content wrap" id="_content" data-uid="known_limitations">
 <h1 id="known-limitations">Known Limitations</h1>
 
-<p>The base of the <code>ValueStringBuilder</code> is a <code>ref struct</code>. With that, there are certain limitations, which might make it not a good fit for your needs.</p>
+<p><code>ValueStringBuilder</code> is a <code>ref struct</code>. With that comes certain limitations which might make it not a good fit for your needs.</p>
 <ul>
-<li><code>ref struct</code>s can only live on the <strong>stack</strong> and therefore can not be a field for a <strong>class</strong> or a non <strong>ref struct</strong>.</li>
-<li>Therefore they can't be boxed to <code>ValueType</code> or <code>Object</code>.</li>
-<li>Can't be captured by a lambda expression (aka closure).</li>
+<li><code>ref struct</code>s can only live on the <strong>stack</strong> and therefore cannot be assigned to a field (except for in another <code>ref struct</code>s).</li>
+<li>Can't be boxed as <code>object</code> or <code>ValueType</code>.</li>
+<li>Can't be captured by a closure (lambda expression or anonymous function).</li>
 <li>Can't be used in <code>async</code> methods.</li>
-<li>Can't be used in methods that use the <code>yield</code> keyword</li>
+<li>Can't be used in methods containing <code>yield</code>.</li>
 </ul>
-<p>If not off this applies to your use case, you are good to go. Using <code>ref struct</code> is a trade for performance and fewer allocations in contrast to its use cases.</p>
-<p><code>ValueStringBuilder</code> offers the possibility to &quot;convert&quot; it into a &quot;regular&quot; <code>System.Text.StringBuilder</code>. Check out the following extension method via the <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilderExtensions.html">ValueStringBuilderExtensions</a>.</p>
+<p>If none of these affect your use case, you're good to go. Using <code>ref struct</code> trades away flexibility in exchange for performance.</p>
+<p><code>ValueStringBuilder</code> can be converted to a <code>System.Text.StringBuilder</code> using an extension method in <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilderExtensions.html">ValueStringBuilderExtensions</a>.</p>
 <h2 id="fluent-notation">Fluent notation</h2>
-<p>The normal <code>StringBuilder</code> offers a fluent way of appending new strings as follows:</p>
+<p>The built-in <code>StringBuilder</code> offers a fluent way of appending strings:</p>
 <pre><code class="lang-csharp">var stringBuilder = new StringBuilder();
 var greeting = stringBuilder
     .AppendLine(&quot;Hello&quot;)
@@ -90,16 +90,16 @@ var greeting = stringBuilder
     .Append(&quot;Not a new line afterwards&quot;)
     .ToString();
 </code></pre>
-<p>This does not work with the <code>ValueStringBuilder</code>. The simple reason: <code>struct</code>s can't return <code>ref this</code>. If we don't return the reference then new allocations are introduced and can also lead to potential bugs/issues. Therefore it is a conscious design decision not to allow fluent notation.</p>
+<p>This does not work with <code>ValueStringBuilder</code>. The reason: <code>struct</code>s can't return <code>ref this</code>. If we return by-value then the builder is copied and the original will not be updated. Therefore it's a conscious design decision not to allow fluent notation.</p>
 <h2 id="idisposable">IDisposable</h2>
-<p>The <code>ValueStringBuilder</code> does not directly implement <code>IDisposable</code> as <code>ref struct</code>s are not allowed to do so (as they might get boxed in the process, which violates the rule of <code>ref struct</code>s). Still, the <code>using</code> statement can be used with the <code>ValueStringBuilder</code>. It is used to return rented memory from an array pool if any is taken.</p>
+<p><code>ValueStringBuilder</code> implements <code>IDisposable</code> (even though it cannot be boxed). The reason is to return any rented arrays to the array pool. As such, the <code>using</code> keyword should be used with <code>ValueStringBuilder</code>.</p>
 <pre><code class="lang-csharp">using var stringBuilder = new ValueStringBuilder();
 </code></pre>
-<p>There are scenarios, where you can elide the <code>using</code> keyword. Exactly then when you provide the buffer in the first place and you are <strong>sure</strong> that no internal growing has to be done. This should only be done if you can guarantee that.</p>
-<pre><code class="lang-csharp">// Reserve 128 bytes on the stack and don't use the using statement
-var stringBuilder = new ValueStringBuilder(stackalloc char[128]);
-
-stringBuilder.Append(&quot;Hello World&quot;); // Uses 11 bytes
+<p>The only scenario where you can avoid disposing the <code>ValueStringBuilder</code> is when you initialize it with your own buffer and you are <strong>sure</strong> that the capacity will not increase. It is recommended to dispose it anyway to make sure.</p>
+<pre><code class="lang-csharp">// Reserve 128 bytes on the stack and omit the using keyword
+using var stringBuilder = new ValueStringBuilder(stackalloc char[128]);
+// Append 11 bytes
+stringBuilder.Append(&quot;Hello World&quot;);
 return stringBuilder.ToString();
 </code></pre>
 </article>

--- a/articles/pass_to_method.html
+++ b/articles/pass_to_method.html
@@ -71,36 +71,23 @@
             <article class="content wrap" id="_content" data-uid="pass_to_method">
 <h1 id="passing-the-valuestringbuilder-to-a-method">Passing the <code>ValueStringBuilder</code> to a method</h1>
 
-<p>As the <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilder.html">ValueStringBuilder</a> is <code>ref struct</code> you should be careful when passing the instance around. You should pass the reference and not the instance.</p>
+<p>As <a class="xref" href="../api/LinkDotNet.StringBuilder.ValueStringBuilder.html">ValueStringBuilder</a> is a <code>ref struct</code>, you should be careful when passing the instance around. You should pass by-reference and not by-value.</p>
 <pre><code class="lang-csharp">public void MyFunction()
 {
-    var stringBuilder = new ValueStringBuilder();
+    using var stringBuilder = new ValueStringBuilder();
     stringBuilder.Append(&quot;Hello &quot;);
     AppendMore(ref stringBuilder);
 }
 
-private void AppendMore(ref ValueStringBuilder builder)
+private void AppendMore(ref ValueStringBuilder stringBuilder)
 {
-    builder.Append(&quot;World&quot;);
+    stringBuilder.Append(&quot;World&quot;);
 }
 </code></pre>
 <p>This will print: <code>Hello World</code></p>
 <blockquote>
-<p>⚠️ The following code snippet will show how it <em>does not</em> work. If the instance is passed not via reference but via value then first allocations will happen and second the end result is not what one would expect.</p>
+<p>⚠️ If the <code>ref</code> keywords are omitted, the builder is passed by-value and this will print: <code>Hello </code>.
 </blockquote>
-<pre><code class="lang-csharp">public void MyFunction()
-{
-    var stringBuilder = new ValueStringBuilder();
-    stringBuilder.Append(&quot;Hello &quot;);
-    AppendMore(stringBuilder);
-}
-
-private void AppendMore(ValueStringBuilder builder)
-{
-    builder.Append(&quot;World&quot;);
-}
-</code></pre>
-<p>This will print: <code>Hello </code>.</p>
 </article>
           </div>
           

--- a/index.html
+++ b/index.html
@@ -67,30 +67,29 @@
 <a href="https://www.nuget.org/packages/LinkDotNet.StringBuilder/"><img src="https://img.shields.io/nuget/dt/LinkDotNet.StringBuilder" alt="Nuget"></a>
 <a href="https://github.com/linkdotnet/StringBuilder/releases"><img src="https://img.shields.io/github/v/tag/linkdotnet/StringBuilder?include_prereleases&amp;logo=github&amp;style=flat-square" alt="GitHub tag"></a></p>
 <h1 id="valuestringbuilder-a-fast-and-low-allocation-stringbuilder-for-net">ValueStringBuilder: A fast and low allocation StringBuilder for .NET</h1>
-<p><strong>ValueStringBuilder</strong> aims to be as fast as possible with a minimal amount of allocation memory. This documentation will showcase to you how to use the <code>ValueStringBuilder</code> as well as what are some limitations coming with it. If you have questions or feature requests just head over to the <a href="https://github.com/linkdotnet/StringBuilder">GitHub</a> repository and file an issue.</p>
-<p>The library makes heavy use of <code>Span&lt;T&gt;</code>, <code>stackalloc</code> and <code>ArrayPool</code>s to achieve low allocations and fast performance.</p>
+<p><code>ValueStringBuilder</code> is a performant, low-allocation alternative to .NET's <code>StringBuilder</code>. This documentation will show you how to use the <code>ValueStringBuilder</code> as well as its limitations. If you have questions or feature requests just head over to the <a href="https://github.com/linkdotnet/StringBuilder">GitHub</a> repository and file an issue.</p>
+<p>The library makes heavy use of <code>Span&lt;T&gt;</code>, <code>stackalloc</code> and <code>ArrayPool&lt;T&gt;</code> to achieve low allocations and fast performance.</p>
 <h2 id="download">Download</h2>
-<p>The package is hosted on <a href="(https://www.nuget.org/packages/LinkDotNet.StringBuilder/)">nuget.org</a>, so easily add the package reference:</p>
+<p>The package is hosted on <a href="(https://www.nuget.org/packages/LinkDotNet.StringBuilder/)">nuget.org</a>, so simply reference the package:</p>
 <blockquote>
 <p>PM&gt; Install-Package LinkDotNet.StringBuilder</p>
 </blockquote>
-<p>Afterwards, you can simply use it. It tries to mimic the API of the <code>StringBuilder</code> to a certain extent so for simpler cases you can exchange those two.</p>
 <h2 id="example-usage">Example usage</h2>
-<p>The API is leaning towards the normal <code>StringBuilder</code> which is part of the .net framework itself. The main key difference is, that the <code>ValueStringBuilder</code> does <strong>not</strong> use the fluent notation of its &quot;big brother&quot;.</p>
-<pre><code class="lang-csharp">var stringBuilder = new ValueStringBuilder();
+<p><code>ValueStringBuilder</code> mostly mimics .NET's <code>StringBuilder</code> meaning it's similar to use. The main difference is, that <code>ValueStringBuilder</code> does <strong>not</strong> support the fluent notation of its big brother.</p>
+<pre><code class="lang-csharp">using var stringBuilder = new ValueStringBuilder(); // Don't forget the 'using' keyword!
 stringBuilder.AppendLine(&quot;Hello World&quot;);
 stringBuilder.Append(&quot;2+2=&quot;);
 stringBuilder.Append(4);
 
-Console.Write(stringBuilder.ToString());
+Console.WriteLine(stringBuilder.ToString());
 </code></pre>
-<p>This will print</p>
+<p>This will print:</p>
 <pre><code>Hello World
 2+2=4
 </code></pre>
-<p>There are also convenient helper methods like this:</p>
-<pre><code class="lang-csharp">_ = ValueStringBuilder.Concat(&quot;Hello&quot;, &quot; &quot;, &quot;World&quot;); // &quot;Hello World&quot;
-_ = ValueStringBuilder.Concat(&quot;Hello&quot;, 1, 2, 3, &quot;!&quot;); // &quot;Hello123!&quot;
+<p>There are also convenient static methods:</p>
+<pre><code class="lang-csharp">Console.WriteLine(ValueStringBuilder.Concat(&quot;Hello&quot;, &quot; &quot;, &quot;World&quot;)); // &quot;Hello World&quot;
+Console.WriteLine(ValueStringBuilder.Concat(&quot;Hello&quot;, 1, 2, 3, &quot;!&quot;)); // &quot;Hello123!&quot;
 </code></pre>
 </article>
           </div>


### PR DESCRIPTION
I've made a lot of changes to the GitHub Pages documentation including:
- Improved grammar.
- Added missing `using`s in examples.
- Updated information about `IDisposable`