### PR TITLE
Fix link formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
 <p><code>ValueStringBuilder</code> is a performant, low-allocation alternative to .NET's <code>StringBuilder</code>. This documentation will show you how to use the <code>ValueStringBuilder</code> as well as its limitations. If you have questions or feature requests just head over to the <a href="https://github.com/linkdotnet/StringBuilder">GitHub</a> repository and file an issue.</p>
 <p>The library makes heavy use of <code>Span&lt;T&gt;</code>, <code>stackalloc</code> and <code>ArrayPool&lt;T&gt;</code> to achieve low allocations and fast performance.</p>
 <h2 id="download">Download</h2>
-<p>The package is hosted on <a href="(https://www.nuget.org/packages/LinkDotNet.StringBuilder/)">nuget.org</a>, so simply reference the package:</p>
+<p>The package is hosted on <a href="https://www.nuget.org/packages/LinkDotNet.StringBuilder/">nuget.org</a>, so simply reference the package:</p>
 <blockquote>
 <p>PM&gt; Install-Package LinkDotNet.StringBuilder</p>
 </blockquote>


### PR DESCRIPTION
Noticed the nuget link wasn't working.

This surely isn't the best way to be editing the documentation (can't actually be certain because I've never used GH Pages, but it seems wrong), but I've made the fix directly to the html because I see that #254 also made a load of direct edits, so if I were to edit the md file in the main branch as I had initially expected to be doing, it would overwrite all that work. You may want to pull the changes back in to the md files, if possible. 