### PR TITLE
Improve Concat helpers

### DIFF
--- a/src/LinkDotNet.StringBuilder/ValueStringBuilder.Concat.Helper.cs
+++ b/src/LinkDotNet.StringBuilder/ValueStringBuilder.Concat.Helper.cs
@@ -5,15 +5,15 @@ namespace LinkDotNet.StringBuilder;
 public ref partial struct ValueStringBuilder
 {
     /// <summary>
-    /// Concatenates multiple objects together.
+    /// Concatenates the string representation of multiple objects together.
     /// </summary>
-    /// <param name="values">Values to be concatenated together.</param>
-    /// <typeparam name="T">Any given type, which can be translated to <see cref="string"/>.</typeparam>
-    /// <returns>Concatenated string or an empty string if <paramref name="values"/> is empty.</returns>
+    /// <param name="values">Values to be concatenated.</param>
+    /// <typeparam name="T">Any type for <paramref name="values"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <returns>The concatenated string, or an empty string if <paramref name="values"/> is empty.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Concat<T>(params scoped ReadOnlySpan<T> values)
     {
-        if (values.Length == 0)
+        if (values.IsEmpty)
         {
             return string.Empty;
         }
@@ -25,13 +25,28 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Concatenates two different types together.
+    /// Creates the string representation of an object.
     /// </summary>
-    /// <typeparam name="T1">Typeparameter of <paramref name="arg1"/>.</typeparam>
-    /// <typeparam name="T2">Typeparameter of <paramref name="arg2"/>.</typeparam>
-    /// <param name="arg1">First argument.</param>
-    /// <param name="arg2">Second argument.</param>
-    /// <returns>String representation of the concateneted result.</returns>
+    /// <typeparam name="T1">Any type for <paramref name="arg1"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <param name="arg1">First value to be concatenated.</param>
+    /// <returns>The string representation of the object.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string Concat<T1>(T1 arg1)
+    {
+        using var sb = new ValueStringBuilder(stackalloc char[128]);
+        sb.AppendInternal(arg1);
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Concatenates the string representation of two objects together.
+    /// </summary>
+    /// <typeparam name="T1">Any type for <paramref name="arg1"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T2">Any type for <paramref name="arg2"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <param name="arg1">First value to be concatenated.</param>
+    /// <param name="arg2">Second value to be concatenated.</param>
+    /// <returns>The concatenated string.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Concat<T1, T2>(T1 arg1, T2 arg2)
     {
@@ -43,15 +58,15 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Concatenates two different types together.
+    /// Concatenates the string representation of three objects together.
     /// </summary>
-    /// <typeparam name="T1">Typeparameter of <paramref name="arg1"/>.</typeparam>
-    /// <typeparam name="T2">Typeparameter of <paramref name="arg2"/>.</typeparam>
-    /// <typeparam name="T3">Typeparameter of <paramref name="arg3"/>.</typeparam>
-    /// <param name="arg1">First argument.</param>
-    /// <param name="arg2">Second argument.</param>
-    /// <param name="arg3">Third argument.</param>
-    /// <returns>String representation of the concateneted result.</returns>
+    /// <typeparam name="T1">Any type for <paramref name="arg1"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T2">Any type for <paramref name="arg2"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T3">Any type for <paramref name="arg3"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <param name="arg1">First value to be concatenated.</param>
+    /// <param name="arg2">Second value to be concatenated.</param>
+    /// <param name="arg3">Third value to be concatenated.</param>
+    /// <returns>The concatenated string.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Concat<T1, T2, T3>(T1 arg1, T2 arg2, T3 arg3)
     {
@@ -64,17 +79,17 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Concatenates two different types together.
+    /// Concatenates the string representation of four objects together.
     /// </summary>
-    /// <typeparam name="T1">Typeparameter of <paramref name="arg1"/>.</typeparam>
-    /// <typeparam name="T2">Typeparameter of <paramref name="arg2"/>.</typeparam>
-    /// <typeparam name="T3">Typeparameter of <paramref name="arg3"/>.</typeparam>
-    /// <typeparam name="T4">Typeparameter of <paramref name="arg4"/>.</typeparam>
-    /// <param name="arg1">First argument.</param>
-    /// <param name="arg2">Second argument.</param>
-    /// <param name="arg3">Third argument.</param>
-    /// <param name="arg4">Fourth argument.</param>
-    /// <returns>String representation of the concateneted result.</returns>
+    /// <typeparam name="T1">Any type for <paramref name="arg1"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T2">Any type for <paramref name="arg2"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T3">Any type for <paramref name="arg3"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T4">Any type for <paramref name="arg4"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <param name="arg1">First value to be concatenated.</param>
+    /// <param name="arg2">Second value to be concatenated.</param>
+    /// <param name="arg3">Third value to be concatenated.</param>
+    /// <param name="arg4">Fourth value to be concatenated.</param>
+    /// <returns>The concatenated string.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Concat<T1, T2, T3, T4>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
     {
@@ -88,19 +103,19 @@ public ref partial struct ValueStringBuilder
     }
 
     /// <summary>
-    /// Concatenates two different types together.
+    /// Concatenates the string representation of five objects together.
     /// </summary>
-    /// <typeparam name="T1">Typeparameter of <paramref name="arg1"/>.</typeparam>
-    /// <typeparam name="T2">Typeparameter of <paramref name="arg2"/>.</typeparam>
-    /// <typeparam name="T3">Typeparameter of <paramref name="arg3"/>.</typeparam>
-    /// <typeparam name="T4">Typeparameter of <paramref name="arg4"/>.</typeparam>
-    /// <typeparam name="T5">Typeparameter of <paramref name="arg5"/>.</typeparam>
-    /// <param name="arg1">First argument.</param>
-    /// <param name="arg2">Second argument.</param>
-    /// <param name="arg3">Third argument.</param>
-    /// <param name="arg4">Fourth argument.</param>
-    /// <param name="arg5">Fifth argument.</param>
-    /// <returns>String representation of the concateneted result.</returns>
+    /// <typeparam name="T1">Any type for <paramref name="arg1"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T2">Any type for <paramref name="arg2"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T3">Any type for <paramref name="arg3"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T4">Any type for <paramref name="arg4"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <typeparam name="T5">Any type for <paramref name="arg5"/> that can be converted to <see cref="string"/>.</typeparam>
+    /// <param name="arg1">First value to be concatenated.</param>
+    /// <param name="arg2">Second value to be concatenated.</param>
+    /// <param name="arg3">Third value to be concatenated.</param>
+    /// <param name="arg4">Fourth value to be concatenated.</param>
+    /// <param name="arg5">Fifth value to be concatenated.</param>
+    /// <returns>The concatenated string.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Concat<T1, T2, T3, T4, T5>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
     {

--- a/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilderTests.cs
+++ b/tests/LinkDotNet.StringBuilder.UnitTests/ValueStringBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LinkDotNet.StringBuilder.UnitTests;
+namespace LinkDotNet.StringBuilder.UnitTests;
 
 public class ValueStringBuilderTests
 {
@@ -363,7 +363,15 @@ public class ValueStringBuilderTests
     }
 
     [Fact]
-    public void ConcatDifferentTypesWithTwoArguments()
+    public void ShouldConcatOneObjectTogether()
+    {
+        var result = ValueStringBuilder.Concat(1);
+
+        result.ShouldBe("1");
+    }
+
+    [Fact]
+    public void ShouldConcatTwoObjectsTogether()
     {
         var result = ValueStringBuilder.Concat("Test", 1);
 
@@ -371,7 +379,7 @@ public class ValueStringBuilderTests
     }
 
     [Fact]
-    public void ConcatDifferentTypesWithThreeArguments()
+    public void ShouldConcatThreeObjectsTogether()
     {
         var result = ValueStringBuilder.Concat("Test", 1, 2);
 
@@ -379,7 +387,7 @@ public class ValueStringBuilderTests
     }
 
     [Fact]
-    public void ConcatDifferentTypesWithFourArguments()
+    public void ShouldConcatFourObjectsTogether()
     {
         var result = ValueStringBuilder.Concat("Test", 1, 2, 3);
 
@@ -387,7 +395,7 @@ public class ValueStringBuilderTests
     }
 
     [Fact]
-    public void ConcatDifferentTypesWithFiveArguments()
+    public void ShouldConcatFiveObjectsTogether()
     {
         var result = ValueStringBuilder.Concat("Test", 1, 2, 3, 4);
 


### PR DESCRIPTION
Various changes to the `ValueStringBuilder.Concat` helpers:
- Rewrote the documentation to make it more clear/consistent.
- Added `ValueStringBuilder.Concat` with only one argument, matching `string.Concat`.